### PR TITLE
12 add option to run only local sampler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 docs/build/*
 *_autosummary
 README.md
+*settings.json


### PR DESCRIPTION
Use Jax array to store results variables instead of python array.

This reduce the size of get sampler too.