### PR TITLE
17 add options to work with likelihoods not in jax

### DIFF
--- a/example/NonJaxLikelihood.py
+++ b/example/NonJaxLikelihood.py
@@ -1,0 +1,73 @@
+from flowMC.nfmodel.realNVP import RealNVP
+from flowMC.sampler.Gaussian_random_walk import rw_metropolis_sampler
+from flowMC.sampler.MALA import mala_sampler
+import jax
+import jax.numpy as jnp                # JAX NumPy
+import numpy as np  
+from scipy.stats import norm
+from flowMC.sampler.Sampler import Sampler
+from flowMC.utils.PRNG_keys import initialize_rng_keys
+from flowMC.utils.PythonFunctionWrap import wrap_python_log_prob_fn
+
+@wrap_python_log_prob_fn
+def neal_funnel(x):
+    y_pdf = norm.logpdf(x[0],loc=0,scale=3)
+    x_pdf = norm.logpdf(x[1:],loc=0,scale=np.exp(x[0]/2))
+    return y_pdf + np.sum(x_pdf)
+
+
+n_dim = 5
+n_loop = 5
+n_local_steps = 20
+n_global_steps = 100
+n_chains = 100
+stepsize = 0.01
+learning_rate = 0.01
+momentum = 0.9
+num_epochs = 100
+batch_size = 1000
+logging = True
+
+print("Preparing RNG keys")
+rng_key_set = initialize_rng_keys(n_chains,seed=42)
+
+print("Initializing MCMC model and normalizing flow model.")
+
+initial_position = jax.random.normal(rng_key_set[0],shape=(n_chains,n_dim)) #(n_dim, n_chains)
+
+
+model = RealNVP(10,n_dim,64, 1)
+run_mcmc = jax.vmap(rw_metropolis_sampler, in_axes=(0, None, None, 0),
+                    out_axes=0)
+
+print("Initializing sampler class")
+
+nf_sampler = Sampler(n_dim, rng_key_set, model, run_mcmc,
+                    neal_funnel,
+                    n_loop=n_loop,
+                    n_local_steps=n_local_steps,
+                    n_global_steps=n_global_steps,
+                    n_chains=n_chains,
+                    n_epochs=num_epochs,
+                    n_nf_samples=100,
+                    learning_rate=learning_rate,
+                    momentum=momentum,
+                    batch_size=batch_size,
+                    stepsize=stepsize)
+
+print("Sampling")
+
+nf_sampler.sample(initial_position)
+chains, log_prob, local_accs, global_accs, loss_vals = nf_sampler.get_sampler_state()
+nf_samples = nf_sampler.sample_flow()
+
+import corner
+import matplotlib.pyplot as plt
+
+# Plot one chain to show the jump
+plt.plot(chains[70,:,0],chains[70,:,1])
+plt.show()
+plt.close()
+
+# Plot all chains
+corner.corner(chains.reshape(-1,n_dim), labels=["$x_1$", "$x_2$", "$x_3$", "$x_4$", "$x_5$"])

--- a/src/flowMC/sampler/Gaussian_random_walk.py
+++ b/src/flowMC/sampler/Gaussian_random_walk.py
@@ -1,9 +1,10 @@
+from turtle import pos
 import jax
 import jax.numpy as jnp
 from functools import partial
 
 # @partial(jax.jit, static_argnums=(1,))
-def rw_metropolis_kernel(rng_key, logpdf, position, log_prob):
+def rw_metropolis_kernel(rng_key, logpdf, position, log_prob, dt=0.1):
     """Moves the chains by one step using the Random Walk Metropolis algorithm.
     Attributes
     ----------
@@ -21,7 +22,7 @@ def rw_metropolis_kernel(rng_key, logpdf, position, log_prob):
         The next positions of the chains along with their log probability.
     """
     key1, key2 = jax.random.split(rng_key)
-    move_proposal = jax.random.normal(key1, shape=position.shape) * 0.1
+    move_proposal = jax.random.normal(key1, shape=position.shape) * dt
     proposal = position + move_proposal
     proposal_log_prob = logpdf(proposal)
 
@@ -30,29 +31,31 @@ def rw_metropolis_kernel(rng_key, logpdf, position, log_prob):
 
     position = jnp.where(do_accept, proposal, position)
     log_prob = jnp.where(do_accept, proposal_log_prob, log_prob)
-    return position, log_prob, do_accept.astype(jnp.int8)
+    return position, log_prob, do_accept
 
 
 # @partial(jax.jit, static_argnums=(1, 2))
-def rw_metropolis_sampler(rng_key, n_samples, logpdf, initial_position):
+def rw_metropolis_sampler(rng_key, n_steps, logpdf, initial_position):
 
     def mh_update_sol2(i, state):
         key, positions, log_prob, acceptance = state
         _, key = jax.random.split(key)
-        new_position, new_log_prob, accept_local = rw_metropolis_kernel(key, logpdf, positions[i-1], log_prob)
-        positions=positions.at[i].set(new_position)
-        acceptance += accept_local
-        return (key, positions, new_log_prob, acceptance)
+        new_position, new_log_prob, do_accept = rw_metropolis_kernel(key, logpdf, positions[i-1], log_prob[i-1])
+        positions = positions.at[i].set(new_position)
+        log_prob = log_prob.at[i].set(new_log_prob)
+        acceptance = acceptance.at[i].set(do_accept)
+        return (key, positions, log_prob, acceptance)
 
 
     logp = logpdf(initial_position)
-    acceptance = jnp.zeros(logp.shape)
-    all_positions = jnp.zeros((n_samples,)+initial_position.shape) + initial_position
-    initial_state = (rng_key,all_positions, logp, acceptance)
-    rng_key, all_positions, log_prob, acceptance = jax.lax.fori_loop(1, n_samples, 
+    acceptance = jnp.zeros((n_steps,))
+    all_positions = jnp.zeros((n_steps,)+initial_position.shape) + initial_position
+    all_logp = jnp.zeros((n_steps,)) + logp
+    initial_state = (rng_key, all_positions, all_logp, acceptance)
+    rng_key, all_positions, all_logp, acceptance = jax.lax.fori_loop(1, n_steps, 
                                                    mh_update_sol2, 
                                                    initial_state)
     
     
-    return rng_key, all_positions, log_prob, acceptance
+    return rng_key, all_positions, all_logp, acceptance
 

--- a/src/flowMC/sampler/Gaussian_random_walk.py
+++ b/src/flowMC/sampler/Gaussian_random_walk.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 from functools import partial
 
-@partial(jax.jit, static_argnums=(1,))
+# @partial(jax.jit, static_argnums=(1,))
 def rw_metropolis_kernel(rng_key, logpdf, position, log_prob):
     """Moves the chains by one step using the Random Walk Metropolis algorithm.
     Attributes
@@ -33,7 +33,7 @@ def rw_metropolis_kernel(rng_key, logpdf, position, log_prob):
     return position, log_prob, do_accept.astype(jnp.int8)
 
 
-@partial(jax.jit, static_argnums=(1, 2))
+# @partial(jax.jit, static_argnums=(1, 2))
 def rw_metropolis_sampler(rng_key, n_samples, logpdf, initial_position):
 
     def mh_update_sol2(i, state):

--- a/src/flowMC/sampler/Sampler.py
+++ b/src/flowMC/sampler/Sampler.py
@@ -87,13 +87,11 @@ class Sampler(object):
         """
 
         last_step = initial_position
-        rng_keys_nf = self.rng_keys_nf
-        rng_keys_mcmc = self.rng_keys_mcmc
         state = self.state
 
         for i in range(self.n_loop):
-            rng_keys_nf, rng_keys_mcmc, state, last_step = self.sampling_loop(
-                rng_keys_nf, rng_keys_mcmc, state, last_step,)
+            self.rng_keys_nf, self.rng_keys_mcmc, state, last_step = self.sampling_loop(
+                self.rng_keys_nf, self.rng_keys_mcmc, state, last_step)
 
   
         # return chains, log_prob, nf_samples, self.local_accs, global_accs, loss_vals
@@ -117,14 +115,14 @@ class Sampler(object):
 
         if self.d_likelihood is None:
             rng_keys_mcmc, positions, log_prob, local_acceptance = self.local_sampler(
-                rng_keys_mcmc, self.n_local_steps, self.likelihood, initial_position, self.stepsize
-                )
+                rng_keys_mcmc, self.n_local_steps, self.likelihood, initial_position)
         else:
             rng_keys_mcmc, positions, log_prob, local_acceptance = self.local_sampler(
                 rng_keys_mcmc, self.n_local_steps, self.likelihood, self.d_likelihood, initial_position, self.stepsize
                 )
 
         log_prob_output = np.copy(log_prob)
+
         flat_chain = positions.reshape(-1, self.n_dim)
         if self.use_global == True:
             rng_keys_nf, state, loss_values = train_flow(rng_keys_nf, self.nf_model, state, flat_chain,

--- a/src/flowMC/utils/PythonFunctionWrap.py
+++ b/src/flowMC/utils/PythonFunctionWrap.py
@@ -1,0 +1,73 @@
+from functools import wraps
+from typing import Any, Callable, List, Tuple, Dict, Iterable, NamedTuple, Union
+
+Array = Any
+PyTree = Union[Array, Iterable[Array], Dict[Any, Array], NamedTuple]
+SampleStats = Dict[str, Array]
+Extras = PyTree
+
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax._src import dtypes
+from jax.custom_batching import custom_vmap
+from jax.experimental import host_callback
+from jax.tree_util import tree_flatten
+
+
+
+def wrap_python_log_prob_fn(
+    python_log_prob_fn: Callable[..., Array]
+) -> LogProbFn:
+    @custom_vmap
+    @wraps(python_log_prob_fn)
+    def log_prob_fn(params: Array) -> Array:
+        dtype = _tree_dtype(params)
+        return host_callback.call(
+            python_log_prob_fn,
+            params,
+            result_shape=jax.ShapeDtypeStruct((), dtype),
+        )
+
+    @log_prob_fn.def_vmap
+    def _(
+        axis_size: int, in_batched: List[bool], params: Array
+    ) -> Tuple[Array, bool]:
+        del axis_size, in_batched
+
+        if _arraylike(params):
+            flat_params = params
+            eval_one = python_log_prob_fn
+        else:
+            flat_params, unravel = ravel_ensemble(params)
+            eval_one = lambda x: python_log_prob_fn(unravel(x))
+
+        result_shape = jax.ShapeDtypeStruct(
+            (flat_params.shape[0],), flat_params.dtype
+        )
+        return (
+            host_callback.call(
+                lambda y: np.stack([eval_one(x) for x in y]),
+                flat_params,
+                result_shape=result_shape,
+            ),
+            True,
+        )
+
+    return log_prob_fn
+
+
+def _tree_dtype(tree: PyTree) -> Any:
+    leaves, _ = tree_flatten(tree)
+    from_dtypes = [dtypes.dtype(l) for l in leaves]
+    return dtypes.result_type(*from_dtypes)
+
+
+def _arraylike(x: Array) -> bool:
+    return (
+        isinstance(x, np.ndarray)
+        or isinstance(x, jnp.ndarray)
+        or hasattr(x, "__jax_array__")
+        or np.isscalar(x)
+    )

--- a/src/flowMC/utils/PythonFunctionWrap.py
+++ b/src/flowMC/utils/PythonFunctionWrap.py
@@ -1,25 +1,27 @@
+import warnings
 from functools import wraps
-from typing import Any, Callable, List, Tuple, Dict, Iterable, NamedTuple, Union
+from typing import Any, List, Dict, Callable, Iterable, Tuple, NamedTuple, Union
 
 Array = Any
 PyTree = Union[Array, Iterable[Array], Dict[Any, Array], NamedTuple]
 SampleStats = Dict[str, Array]
 Extras = PyTree
 
-
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax import lax
 from jax._src import dtypes
+from jax._src.util import safe_zip
 from jax.custom_batching import custom_vmap
 from jax.experimental import host_callback
-from jax.tree_util import tree_flatten
+from jax.tree_util import tree_flatten, tree_unflatten
 
 
 
 def wrap_python_log_prob_fn(
     python_log_prob_fn: Callable[..., Array]
-) -> LogProbFn:
+):
     @custom_vmap
     @wraps(python_log_prob_fn)
     def log_prob_fn(params: Array) -> Array:
@@ -71,3 +73,60 @@ def _arraylike(x: Array) -> bool:
         or hasattr(x, "__jax_array__")
         or np.isscalar(x)
     )
+
+
+UnravelFn = Callable[[Array], PyTree]
+
+zip = safe_zip
+
+
+def ravel_ensemble(coords: PyTree) -> Tuple[Array, UnravelFn]:
+    leaves, treedef = tree_flatten(coords)
+    flat, unravel_inner = _ravel_inner(leaves)
+    unravel_one = lambda flat: tree_unflatten(treedef, unravel_inner(flat))
+    return flat, unravel_one
+
+
+def _ravel_inner(lst: List[Array]) -> Tuple[Array, UnravelFn]:
+    if not lst:
+        return jnp.array([], jnp.float32), lambda _: []
+    from_dtypes = [dtypes.dtype(l) for l in lst]
+    to_dtype = dtypes.result_type(*from_dtypes)
+    shapes = [jnp.shape(x)[1:] for x in lst]
+    indices = np.cumsum([int(np.prod(s)) for s in shapes])
+
+    if all(dt == to_dtype for dt in from_dtypes):
+        del from_dtypes, to_dtype
+
+        def unravel(arr: Array) -> PyTree:
+            chunks = jnp.split(arr, indices[:-1])
+            return [
+                chunk.reshape(shape) for chunk, shape in zip(chunks, shapes)
+            ]
+
+        ravel = lambda arg: jnp.concatenate([jnp.ravel(e) for e in arg])
+        raveled = jax.vmap(ravel)(lst)
+        return raveled, unravel
+
+    else:
+
+        def unravel(arr: Array) -> PyTree:
+            arr_dtype = dtypes.dtype(arr)
+            if arr_dtype != to_dtype:
+                raise TypeError(
+                    f"unravel function given array of dtype {arr_dtype}, "
+                    f"but expected dtype {to_dtype}"
+                )
+            chunks = jnp.split(arr, indices[:-1])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return [
+                    lax.convert_element_type(chunk.reshape(shape), dtype)
+                    for chunk, shape, dtype in zip(chunks, shapes, from_dtypes)
+                ]
+
+        ravel = lambda arg: jnp.concatenate(
+            [jnp.ravel(lax.convert_element_type(e, to_dtype)) for e in arg]
+        )
+        raveled = jax.vmap(ravel)(lst)
+        return raveled, unravel

--- a/src/flowMC/utils/PythonFunctionWrap.py
+++ b/src/flowMC/utils/PythonFunctionWrap.py
@@ -48,12 +48,14 @@ def wrap_python_log_prob_fn(
         result_shape = jax.ShapeDtypeStruct(
             (flat_params.shape[0],), flat_params.dtype
         )
-        return (
-            host_callback.call(
+
+        result = host_callback.call(
                 lambda y: np.stack([eval_one(x) for x in y]),
                 flat_params,
                 result_shape=result_shape,
-            ),
+            )
+        return (
+            result,
             True,
         )
 


### PR DESCRIPTION
This add the functionality of wrapping non-Jax likelihood in the framework such that we can interface with external codebase.

1. Add functionality in `util/PythonFunctionWrap.py`
2. Add example script  for sample neal funnel `NonJaxLikleihood.py`
3. Update Gaussian random walk kernel to be compatible with the new API