### PR TITLE
bringing python version to range 3.8 - 3.10.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     tqdm
     distrax
     
-python_requires =  >=3.7
+python_requires =  >=3.8,<3.11
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
This aims at avoiding Python 3.11 with is not supported by Tensorflow, this dependency coming from Jax. 