### PR TITLE
Keep the potential energy (negative log likelihood) instead of the ha…

### DIFF
--- a/src/flowMC/sampler/HMC.py
+++ b/src/flowMC/sampler/HMC.py
@@ -30,10 +30,6 @@ class HMC(LocalSamplerBase):
         self.kinetic = lambda p, params: 0.5*(p**2 * params['inverse_metric']).sum()
         self.grad_kinetic = jax.grad(self.kinetic)
 
-    def get_initial_hamiltonian(self, rng_key: jax.random.PRNGKey, position: jnp.array, params: dict):
-        momentum = jax.random.normal(rng_key, shape=position.shape) * params['inverse_metric'] **-0.5
-        return self.potential(position) + self.kinetic(momentum, params)
-
     def make_kernel(self, return_aux = False) -> Callable:
         """
 
@@ -55,7 +51,7 @@ class HMC(LocalSamplerBase):
             momentum = momentum - 0.5*params['step_size'] * self.grad_potential(position)
             return position, momentum
 
-        def hmc_kernel(rng_key, position, H, params: dict):
+        def hmc_kernel(rng_key, position, PE, params: dict):
             """
 
             Note that since the potential function is the negative log likelihood, hamiltonian is going down, but the likelihood value should go up.
@@ -68,15 +64,17 @@ class HMC(LocalSamplerBase):
             key1, key2 = jax.random.split(rng_key)
 
             momentum = jax.random.normal(key1, shape=position.shape) * params['inverse_metric']**-0.5
+            H = PE + self.kinetic(momentum, params)
             proposed_position, proposed_momentum = leapfrog_step(position, momentum, params)
-            proposed_ham = self.potential(proposed_position) + self.kinetic(proposed_momentum, params)
+            proposed_PE = self.potential(proposed_position)
+            proposed_ham = proposed_PE + self.kinetic(proposed_momentum, params)
             log_acc = H - proposed_ham
             log_uniform = jnp.log(jax.random.uniform(key2))
 
             do_accept = log_uniform < log_acc
 
             position = jnp.where(do_accept, proposed_position, position)
-            log_prob = jnp.where(do_accept, proposed_ham, H)
+            log_prob = jnp.where(do_accept, proposed_PE, PE)
 
             return position, log_prob, do_accept
         
@@ -96,15 +94,15 @@ class HMC(LocalSamplerBase):
         hmc_kernel = self.make_kernel()
 
         def hmc_update(i, state):
-            key, positions, log_Ham, acceptance, params = state
+            key, positions, PE, acceptance, params = state
             _, key = jax.random.split(key)
-            new_position, new_log_Ham, do_accept = hmc_kernel(
-                key, positions[i - 1], log_Ham[i - 1], params
+            new_position, new_PE, do_accept = hmc_kernel(
+                key, positions[i - 1], PE[i - 1], params
             )
             positions = positions.at[i].set(new_position)
-            log_Ham = log_Ham.at[i].set(new_log_Ham)
+            PE = PE.at[i].set(new_PE)
             acceptance = acceptance.at[i].set(do_accept)
-            return (key, positions, log_Ham, acceptance, params)
+            return (key, positions, PE, acceptance, params)
 
         return hmc_update
 
@@ -115,14 +113,14 @@ class HMC(LocalSamplerBase):
             hmc_update = jax.jit(hmc_update)
 
         hmc_update = jax.vmap(hmc_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
-        lh = jax.vmap(self.get_initial_hamiltonian, in_axes=(0, 0, None))
+        lp = jax.vmap(self.potential)
 
         def hmc_sampler(rng_key, n_steps, initial_position):
             
             keys = jax.vmap(jax.random.split)(rng_key)
             rng_key = keys[:, 0]
             rng_init = keys[:, 1]
-            logp = lh(rng_init,initial_position, self.params)
+            logp = lp(initial_position)
             n_chains = rng_key.shape[0]
             acceptance = jnp.zeros(
                 (
@@ -167,10 +165,3 @@ class HMC(LocalSamplerBase):
             momentum = momentum - self.step_size * self.grad_potential(position)
             return position, momentum
         return leapfrog_kernal
-
-
-
-
-
-from tqdm import tqdm
-from functools import partialmethod

--- a/test/test_HMC.py
+++ b/test/test_HMC.py
@@ -25,19 +25,19 @@ initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 
 
 HMC = HMC(dual_moon_pe, True, {"step_size": step_size,"n_leapfrog": n_leapfrog, "inverse_metric": jnp.ones(n_dim)})
 
-initial_Ham = jax.vmap(HMC.get_initial_hamiltonian, in_axes=(0, 0, None))(rng_key_set[1], initial_position, HMC.params)
+initial_PE = jax.vmap(HMC.potential)(initial_position)
 
 HMC_kernel = HMC.make_kernel()
 
-print(HMC_kernel(rng_key_set[0], initial_position[0], initial_Ham[0], HMC.params))
+print(HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], HMC.params))
 
 HMC_update = HMC.make_update()
 HMC_update = jax.vmap(HMC_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)
-initial_Ham = jnp.repeat(initial_Ham[:,None], n_local_steps, 1)
+initial_PE = jnp.repeat(initial_PE[:,None], n_local_steps, 1)
 
-state = (rng_key_set[1], initial_position, initial_Ham, jnp.zeros((n_chains, n_local_steps,1)), HMC.params)
+state = (rng_key_set[1], initial_position, initial_PE, jnp.zeros((n_chains, n_local_steps,1)), HMC.params)
 
 
 HMC_update(1, state)
@@ -52,7 +52,7 @@ from flowMC.sampler.Sampler import Sampler
 
 n_dim = 5
 n_chains = 2
-n_local_steps = 3
+n_local_steps = 20
 n_global_steps = 3
 step_size = 0.1
 n_loop_training = 2


### PR DESCRIPTION
…miltonian in the HMC sampler.

The Hamiltonian used in computing the acceptance rate is now computed every time the momentum is resampled.
Previous we kept the Hamiltonian from previous step but didn't update it after sampling the momentum, which will lead to incorrect acceptance. This is now fixed in this PR.

Need to write the relevant tests for the HMC sampler before merging