### PR TITLE
Data Batching, precompilation, and autotune

### DIFF
--- a/docs/source/api/flowMC.nfmodel.rst
+++ b/docs/source/api/flowMC.nfmodel.rst
@@ -4,6 +4,14 @@ flowMC.nfmodel package
 Submodules
 ----------
 
+flowMC.nfmodel.mlp module
+-------------------------
+
+.. automodule:: flowMC.nfmodel.mlp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 flowMC.nfmodel.realNVP module
 -----------------------------
 

--- a/docs/source/api/flowMC.sampler.rst
+++ b/docs/source/api/flowMC.sampler.rst
@@ -12,6 +12,22 @@ flowMC.sampler.Gaussian\_random\_walk module
    :undoc-members:
    :show-inheritance:
 
+flowMC.sampler.HMC module
+-------------------------
+
+.. automodule:: flowMC.sampler.HMC
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+flowMC.sampler.LocalSampler\_Base module
+----------------------------------------
+
+.. automodule:: flowMC.sampler.LocalSampler_Base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 flowMC.sampler.MALA module
 --------------------------
 

--- a/docs/source/api/flowMC.utils.rst
+++ b/docs/source/api/flowMC.utils.rst
@@ -20,14 +20,6 @@ flowMC.utils.PythonFunctionWrap module
    :undoc-members:
    :show-inheritance:
 
-flowMC.utils.progressBar module
--------------------------------
-
-.. automodule:: flowMC.utils.progressBar
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Module contents
 ---------------
 

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,5 +1,5 @@
-src
-===
+flowMC
+======
 
 .. toctree::
    :maxdepth: 4

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -15,11 +15,11 @@ This page contains information about the most important hyperparameters which af
 +-----------------------+--------------------------+-----------------------+
 | :ref:`local_sampler`  | :ref:`n_loop_training`   | :ref:`nf_variable`    |
 +-----------------------+--------------------------+-----------------------+
-| :ref:`sampler_params` | :ref:`n_loop_production` | :ref:`local_autotune` |
+| :ref:`data`           | :ref:`n_loop_production` | :ref:`local_autotune` |
 +-----------------------+--------------------------+-----------------------+
-| :ref:`likelihood`     | :ref:`n_local_steps`     | :ref:`train_thinning` |
+| :ref:`nf_model`       | :ref:`n_local_steps`     | :ref:`train_thinning` |
 +-----------------------+--------------------------+-----------------------+
-| :ref:`nf_model`       | :ref:`n_global_steps`    |                       |
+|                       | :ref:`n_global_steps`    |                       |
 +-----------------------+--------------------------+-----------------------+
 |                       | :ref:`n_epochs`          |                       |
 +-----------------------+--------------------------+-----------------------+
@@ -51,26 +51,21 @@ rng_key_set
 
 The set of Jax generated PRNG_keys.
 
+.. _data:
+
+data
+^^^^
+
+The data you want to sample from. This is used to precompile the kernels used during the sampling.
+Note that you keep the shape of the data consistent between runs, otherwise it would trigger recompilation.
+If your likelihood does not take any data arguments, simply put it as None should work.
+
 .. _local_sampler:
 
 local_sampler
 ^^^^^^^^^^^^^
 
 Specific local sampler you want to use.
-
-.. _sampler_params:
-
-sampler_params
-^^^^^^^^^^^^^^
-
-Specific parameters from a particular local sampler.
-
-.. _likelihood:
-
-likelihood
-^^^^^^^^^^
-
-Target log-probability density function you want to sample.
 
 .. _nf_model:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -49,8 +49,10 @@ To sample a N dimensional Gaussian, you would do something like:
     from flowMC.utils.PRNG_keys import initialize_rng_keys
     from flowMC.nfmodel.utils import *
 
-    def log_posterior(x):
-        return -0.5 * jnp.sum(x ** 2)
+    def log_posterior(x, data):
+        return -0.5 * jnp.sum((x-data) ** 2)
+
+    data = jnp.arange(5)
 
     n_dim = 5
     n_chains = 10
@@ -63,8 +65,8 @@ To sample a N dimensional Gaussian, you would do something like:
 
     nf_sampler = Sampler(n_dim,
                         rng_key_set,
+                        jnp.arange(n_dim),
                         local_sampler,
-                        log_posterior,
                         model,
                         n_local_steps = 50,
                         n_global_steps = 50,
@@ -73,7 +75,7 @@ To sample a N dimensional Gaussian, you would do something like:
                         batch_size = 1000,
                         n_chains = n_chains)
 
-    nf_sampler.sample(initial_position)
+    nf_sampler.sample(initial_position, data)
     chains,log_prob,local_accs, global_accs = nf_sampler.get_sampler_state().values()
 
 For more examples, have a look at the :ref:`tutorials`. 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -78,9 +78,8 @@ To sample a N dimensional Gaussian, you would do something like:
     nf_sampler.sample(initial_position, data)
     chains,log_prob,local_accs, global_accs = nf_sampler.get_sampler_state().values()
 
-For more examples, have a look at the :ref:`tutorials`. 
-.. `GitHub <https://github.com/kazewong/flowMC/tree/main/example>`_.
-.. In particular, currently the best engineered test case is `dualmoon.py <https://github.com/kazewong/flowMC/blob/main/example/dualmoon.py>`_.
+For more examples, have a look at the :ref:`tutorials` on `GitHub <https://github.com/kazewong/flowMC/tree/main/example>`_.
+In particular, currently the best engineered test case is `dualmoon.py <https://github.com/kazewong/flowMC/blob/main/example/dualmoon.py>`_.
 
 In the ideal case, the only three things you will have to do are:
 

--- a/src/flowMC/sampler/Gaussian_random_walk.py
+++ b/src/flowMC/sampler/Gaussian_random_walk.py
@@ -19,17 +19,23 @@ class GaussianRandomWalk(LocalSamplerBase):
         super().__init__(logpdf, jit, params)
         self.params = params
         self.logpdf = logpdf
+        self.logpdf_vmap = jax.vmap(logpdf, in_axes=(0, None))
         self.verbose = verbose
+        self.kernel = None
+        self.kernel_vmap = None
+        self.update = None
+        self.update_vmap = None
+        self.sampler = None
 
     def make_kernel(self, return_aux = False) -> Callable:
         """
         Making a single update of the random walk
         """
-        def rw_kernel(rng_key, position, log_prob, params = {"step_size": 0.1}):
+        def rw_kernel(rng_key, position, log_prob, data, params = {"step_size": 0.1}):
             key1, key2 = jax.random.split(rng_key)
             move_proposal = jax.random.normal(key1, shape=position.shape) * params['step_size']
             proposal = position + move_proposal
-            proposal_log_prob = self.logpdf(proposal)
+            proposal_log_prob = self.logpdf(proposal, data)
 
             log_uniform = jnp.log(jax.random.uniform(key2))
             do_accept = log_uniform < proposal_log_prob - log_prob
@@ -46,16 +52,17 @@ class GaussianRandomWalk(LocalSamplerBase):
         Making a the random walk update function for multiple steps
         """
 
-        rw_kernel = self.make_kernel()
+        if self.kernel is None:
+            raise ValueError("Kernel not defined. Please run make_kernel first.")
 
         def rw_update(i, state):
-            key, positions, log_p, acceptance, params = state
+            key, positions, log_p, acceptance, data, params = state
             _, key = jax.random.split(key)
-            new_position, new_log_p, do_accept = rw_kernel(key, positions[i-1], log_p[i-1], params)
+            new_position, new_log_p, do_accept = self.kernel(key, positions[i-1], log_p[i-1], data, params)
             positions = positions.at[i].set(new_position)
             log_p = log_p.at[i].set(new_log_p)
             acceptance = acceptance.at[i].set(do_accept)
-            return (key, positions, log_p, acceptance, params)
+            return (key, positions, log_p, acceptance, data, params)
         
         return rw_update
 
@@ -63,31 +70,25 @@ class GaussianRandomWalk(LocalSamplerBase):
         """
         Making the random walk sampler for multiple chains given initial positions
         """
-        rw_update = self.make_update()
-        lp = self.logpdf
+        if self.update is None:
+            raise ValueError("Update function not defined. Please run make_update first.")
 
-        if self.jit:
-            rw_update = jax.jit(rw_update)
-            lp = jax.jit(self.logpdf)
 
-        rw_update = jax.vmap(rw_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
-        lp = jax.vmap(lp)
-
-        def rw_sampler(rng_key, n_steps, initial_position):
-            logp = lp(initial_position)
+        def rw_sampler(rng_key, n_steps, initial_position, data):
+            logp = self.logpdf_vmap(initial_position, data)
             n_chains = rng_key.shape[0]
             acceptance = jnp.zeros((n_chains, n_steps))
             all_positions = (jnp.zeros((n_chains, n_steps) + initial_position.shape[-1:])) + initial_position[:, None]
             all_logp = (jnp.zeros((n_chains, n_steps)) + logp[:, None])
-            state = (rng_key, all_positions, all_logp, acceptance, self.params)
+            state = (rng_key, all_positions, all_logp, acceptance, data, self.params)
             if self.verbose:
                 iterator_loop = tqdm(range(1, n_steps), desc="Sampling Locally", miniters=int(n_steps / 10))
             else:
                 iterator_loop = range(1, n_steps)
 
             for i in iterator_loop:
-                state = rw_update(i, state)
-            return state[:-1]
+                state = self.update_vmap(i, state)
+            return state[:-2]
             
 
         return rw_sampler

--- a/src/flowMC/sampler/LocalSampler_Base.py
+++ b/src/flowMC/sampler/LocalSampler_Base.py
@@ -26,6 +26,7 @@ class LocalSamplerBase:
         self.sampler = self.make_sampler()
 
         if self.jit == True:
+            self.logpdf_vmap = jax.jit(self.logpdf_vmap)
             self.kernel = jax.jit(self.kernel)
             self.kernel_vmap = jax.jit(self.kernel_vmap)
             self.update = jax.jit(self.update)
@@ -35,7 +36,7 @@ class LocalSamplerBase:
         
         key = jax.random.split(jax.random.PRNGKey(0), n_chains)
 
-        self.logpdf_vmap
+        self.logpdf_vmap(jnp.ones((n_chains, n_dims)), data)
         self.kernel_vmap(key, jnp.ones((n_chains, n_dims)), jnp.ones((n_chains, 1)), data, self.params)
         self.update_vmap(1, (key, jnp.ones((n_chains, n_step, n_dims)), jnp.ones((n_chains, n_step, 1)),jnp.zeros((n_chains, n_step, 1)), data, self.params))
         

--- a/src/flowMC/sampler/LocalSampler_Base.py
+++ b/src/flowMC/sampler/LocalSampler_Base.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 from typing import Callable
+import jax
+import jax.numpy as jnp
 class LocalSamplerBase:
 
     def __init__(self, logpdf: Callable, jit: bool, params: dict) -> Callable:
@@ -9,6 +11,34 @@ class LocalSamplerBase:
         self.logpdf = logpdf
         self.jit = jit
         self.params = params
+
+    def precompilation(self, n_chains, n_dims, n_step, data):
+
+        if self.jit == True:
+            print("jit is requested, precompiling kernels and update...")
+        else:
+            print("jit is not requested, compiling only vmap functions...")
+
+        self.kernel = self.make_kernel()
+        self.kernel_vmap = jax.vmap(self.kernel, in_axes = (0, 0, 0, None, None), out_axes=(0, 0, 0))
+        self.update = self.make_update()
+        self.update_vmap = jax.vmap(self.update, in_axes = (None, (0, 0, 0, 0, None, None)), out_axes=(0, 0, 0, 0, None, None))
+        self.sampler = self.make_sampler()
+
+        if self.jit == True:
+            self.kernel = jax.jit(self.kernel)
+            self.kernel_vmap = jax.jit(self.kernel_vmap)
+            self.update = jax.jit(self.update)
+            self.update_vmap = jax.jit(self.update_vmap)
+            self.kernel(jax.random.PRNGKey(0), jnp.ones(n_dims), jnp.ones(1), data, self.params)
+            # self.update(1, (jax.random.PRNGKey(0), jnp.ones(n_dims), jnp.ones(1), jnp.zeros((n_step, 1)), data, self.params))
+        
+        key = jax.random.split(jax.random.PRNGKey(0), n_chains)
+
+        self.logpdf_vmap
+        self.kernel_vmap(key, jnp.ones((n_chains, n_dims)), jnp.ones((n_chains, 1)), data, self.params)
+        self.update_vmap(1, (key, jnp.ones((n_chains, n_step, n_dims)), jnp.ones((n_chains, n_step, 1)),jnp.zeros((n_chains, n_step, 1)), data, self.params))
+        
 
     @abstractmethod
     def make_kernel(self, return_aux = False) -> Callable:

--- a/src/flowMC/sampler/MALA.py
+++ b/src/flowMC/sampler/MALA.py
@@ -30,33 +30,6 @@ class MALA(LocalSamplerBase):
         self.sampler = None
         self.use_autotune = use_autotune
 
-    def precompilation(self, n_chains, n_dims, n_step, data):
-
-        if self.jit == True:
-            print("jit is requested, precompiling kernels and update...")
-        else:
-            print("jit is not requested, compiling only vmap functions...")
-
-        self.kernel = self.make_kernel()
-        self.kernel_vmap = jax.vmap(self.kernel, in_axes = (0, 0, 0, None, None), out_axes=(0, 0, 0))
-        self.update = self.make_update()
-        self.update_vmap = jax.vmap(self.update, in_axes = (None, (0, 0, 0, 0, None, None)), out_axes=(0, 0, 0, 0, None, None))
-        self.sampler = self.make_sampler()
-
-        if self.jit == True:
-            self.kernel = jax.jit(self.kernel)
-            self.kernel_vmap = jax.jit(self.kernel_vmap)
-            self.update = jax.jit(self.update)
-            self.update_vmap = jax.jit(self.update_vmap)
-            self.kernel(jax.random.PRNGKey(0), jnp.ones(n_dims), jnp.ones(1), data, self.params)
-            # self.update(1, (jax.random.PRNGKey(0), jnp.ones(n_dims), jnp.ones(1), jnp.zeros((n_step, 1)), data, self.params))
-        
-        key = jax.random.split(jax.random.PRNGKey(0), n_chains)
-
-        self.kernel_vmap(key, jnp.ones((n_chains, n_dims)), jnp.ones((n_chains, 1)), data, self.params)
-        self.update_vmap(1, (key, jnp.ones((n_chains, n_step, n_dims)), jnp.ones((n_chains, n_step, 1)),jnp.zeros((n_chains, n_step, 1)), data, self.params))
-        
-
     def make_kernel(self, return_aux = False) -> Callable:
         """
         Make a MALA kernel for a given logpdf.

--- a/src/flowMC/sampler/MALA.py
+++ b/src/flowMC/sampler/MALA.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from jax.scipy.stats import multivariate_normal
 from tqdm import tqdm
 from flowMC.sampler.LocalSampler_Base import LocalSamplerBase
+from functools import partialmethod
 
 
 class MALA(LocalSamplerBase):
@@ -16,14 +17,18 @@ class MALA(LocalSamplerBase):
         params: dictionary of parameters for the sampler
     """
 
-    def __init__(self, logpdf: Callable, jit: bool, params: dict, verbose: bool = False) -> Callable:
+    def __init__(self, logpdf: Callable, jit: bool, params: dict, verbose: bool = False, use_autotune = False) -> Callable:
         super().__init__(logpdf, jit, params)
         self.params = params
         self.logpdf = logpdf
+        self.logpdf_vmap = jax.vmap(logpdf)
         self.verbose = verbose
         self.kernel = None
+        self.kernel_vmap = None
         self.update = None
+        self.update_vmap = None
         self.sampler = None
+        self.use_autotune = use_autotune
 
     def make_kernel(self, return_aux = False) -> Callable:
         """
@@ -41,7 +46,7 @@ class MALA(LocalSamplerBase):
             this_log_prob, this_d_log = jax.value_and_grad(self.logpdf)(this_position, data)
             proposal = this_position + jnp.dot(dt2, this_d_log) / 2
             proposal += jnp.dot(dt, jax.random.normal(this_key, shape=this_position.shape))
-            return (proposal,dt), (proposal, this_log_prob, this_d_log)
+            return (proposal,dt, data), (proposal, this_log_prob, this_d_log)
 
         def mala_kernel(rng_key, position, log_prob, data, params = {"step_size": 0.1}):
             """
@@ -85,7 +90,6 @@ class MALA(LocalSamplerBase):
             log_prob = jnp.where(do_accept, logprob[1], logprob[0])
             return position, log_prob, do_accept
 
-        self.kernel = mala_kernel()
         return mala_kernel
 
     def make_update(self) -> Callable:
@@ -93,16 +97,16 @@ class MALA(LocalSamplerBase):
         Make a MALA update function for multiple steps
         """
         if self.kernel is None:
-            mala_kernel = self.make_kernel()
+            self.kernel = self.make_kernel()
 
         def mala_update(i, state):
-            key, positions, log_p, acceptance, params = state
+            key, positions, log_p, acceptance, data, params = state
             _, key = jax.random.split(key)
-            new_position, new_log_p, do_accept = mala_kernel(key, positions[i-1], log_p[i-1], data, params)
+            new_position, new_log_p, do_accept = self.kernel(key, positions[i-1], log_p[i-1], data, params)
             positions = positions.at[i].set(new_position)
             log_p = log_p.at[i].set(new_log_p)
             acceptance = acceptance.at[i].set(do_accept)
-            return (key, positions, log_p, acceptance, params)
+            return (key, positions, log_p, acceptance, data, params)
         
         self.update = mala_update
         return mala_update
@@ -113,65 +117,61 @@ class MALA(LocalSamplerBase):
         """
 
         if self.update is None:
-            mala_update = self.make_update()
-        lp = self.logpdf
+            self.update = self.make_update()
 
         if self.jit:
-            mala_update = jax.jit(mala_update)
-            lp = jax.jit(self.logpdf)
+            self.update = jax.jit(self.update)
+            self.logpdf = jax.jit(self.logpdf)
 
-        mala_update = jax.vmap(mala_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
-        lp = jax.vmap(lp)
+        self.update_vmap = jax.vmap(self.update, in_axes = (None, (0, 0, 0, 0, None, None)), out_axes=(0, 0, 0, 0, None, None))
 
-        def mala_sampler(rng_key, n_steps, initial_position):
-            logp = lp(initial_position)
+        def mala_sampler(rng_key, n_steps, initial_position, data):
+            logp = self.logpdf_vmap(initial_position)
             n_chains = rng_key.shape[0]
             acceptance = jnp.zeros((n_chains, n_steps))
             all_positions = (jnp.zeros((n_chains, n_steps) + initial_position.shape[-1:])) + initial_position[:, None]
             all_logp = (jnp.zeros((n_chains, n_steps)) + logp[:, None])
-            state = (rng_key, all_positions, all_logp, acceptance, self.params)
+            state = (rng_key, all_positions, all_logp, acceptance, data, self.params)
             if self.verbose:
                 iterator_loop = tqdm(range(1, n_steps), desc="Sampling Locally", miniters=int(n_steps / 10))
             else:
                 iterator_loop = range(1, n_steps)
             for i in iterator_loop:
-                state = mala_update(i, state)
+                state = self.update_vmap(i, state)
             return state[:-1]
 
         self.sampler = mala_sampler
         return mala_sampler 
 
-from tqdm import tqdm
-from functools import partialmethod
 
-def mala_sampler_autotune(mala_kernel_vmap, rng_key, initial_position, log_prob, params, max_iter = 30):
-    """
-    Tune the step size of the MALA kernel using the acceptance rate.
+    def mala_sampler_autotune(mala_kernel_vmap, rng_key, initial_position, log_prob, params, max_iter = 30):
+        """
+        Tune the step size of the MALA kernel using the acceptance rate.
 
-    Args:
-        mala_kernel_vmap (Callable): A MALA kernel
-        rng_key: Jax PRNGKey
-        initial_position (n_chains, n_dim): initial position of the chains
-        log_prob (n_chains, ): log-probability of the initial position
-        params (dict): parameters of the MALA kernel
-        max_iter (int): maximal number of iterations to tune the step size
-    """
+        Args:
+            mala_kernel_vmap (Callable): A MALA kernel
+            rng_key: Jax PRNGKey
+            initial_position (n_chains, n_dim): initial position of the chains
+            log_prob (n_chains, ): log-probability of the initial position
+            params (dict): parameters of the MALA kernel
+            max_iter (int): maximal number of iterations to tune the step size
+        """
 
-    tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
+        tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
 
-    counter = 0
-    position, log_prob, do_accept = mala_kernel_vmap(rng_key, initial_position, log_prob, params)
-    acceptance_rate = jnp.mean(do_accept)
-    while (acceptance_rate <= 0.3) or (acceptance_rate >= 0.5):
-        if counter > max_iter:
-            print("Maximal number of iterations reached. Existing tuning with current parameters.")
-            break
-        if acceptance_rate <= 0.3:
-            params['step_size'] *= 0.8
-        elif acceptance_rate >= 0.5:
-            params['step_size'] *= 1.25
-        counter += 1
+        counter = 0
         position, log_prob, do_accept = mala_kernel_vmap(rng_key, initial_position, log_prob, params)
         acceptance_rate = jnp.mean(do_accept)
-    tqdm.__init__ = partialmethod(tqdm.__init__, disable=False)
-    return params
+        while (acceptance_rate <= 0.3) or (acceptance_rate >= 0.5):
+            if counter > max_iter:
+                print("Maximal number of iterations reached. Existing tuning with current parameters.")
+                break
+            if acceptance_rate <= 0.3:
+                params['step_size'] *= 0.8
+            elif acceptance_rate >= 0.5:
+                params['step_size'] *= 1.25
+            counter += 1
+            position, log_prob, do_accept = mala_kernel_vmap(rng_key, initial_position, log_prob, params)
+            acceptance_rate = jnp.mean(do_accept)
+        tqdm.__init__ = partialmethod(tqdm.__init__, disable=False)
+        return params

--- a/src/flowMC/sampler/MALA.py
+++ b/src/flowMC/sampler/MALA.py
@@ -131,7 +131,7 @@ class MALA(LocalSamplerBase):
                 iterator_loop = range(1, n_steps)
             for i in iterator_loop:
                 state = self.update_vmap(i, state)
-            return state[:-1]
+            return state[:-2]
 
         self.sampler = mala_sampler
         return mala_sampler 

--- a/src/flowMC/sampler/Sampler.py
+++ b/src/flowMC/sampler/Sampler.py
@@ -46,8 +46,8 @@ class Sampler():
         self,
         n_dim: int,
         rng_key_set: Tuple,
+        data: jnp.ndarray,
         local_sampler: LocalSamplerBase,
-        likelihood: Callable,
         nf_model: Callable,
         n_loop_training: int = 3,
         n_loop_production: int = 3,
@@ -91,11 +91,12 @@ class Sampler():
 
         # Initialized local and global samplers
 
-        self.likelihood = likelihood
-        self.likelihood_vec = jax.jit(jax.vmap(self.likelihood))
         self.local_sampler_class = local_sampler
-        self.local_sampler = local_sampler.make_sampler()
+        self.local_sampler_class.precompilation(n_chains=n_chains, n_dims=n_dim, n_step=n_local_steps, data=data)
+        self.local_sampler = self.local_sampler_class.sampler
+
         self.local_autotune = local_autotune
+        self.likelihood_vec = self.local_sampler_class.logpdf_vmap
         self.nf_model = nf_model
         if model_init is None:
             model_init = nf_model.init(init_rng_keys_nf, jnp.ones((1, self.n_dim)))
@@ -131,7 +132,7 @@ class Sampler():
         self.summary['training'] = training
         self.summary['production'] = production
 
-    def sample(self, initial_position):
+    def sample(self, initial_position, data):
         """
         Sample from the posterior using the local sampler.
 
@@ -149,14 +150,14 @@ class Sampler():
         # Note that auto-tune function needs to have the same number of steps
         # as the actual sampling loop to avoid recompilation.
 
-        self.local_sampler_tuning(initial_position)
+        self.local_sampler_tuning(initial_position, data)
         last_step = initial_position
         if self.use_global == True:
-            last_step = self.global_sampler_tuning(last_step)
+            last_step = self.global_sampler_tuning(last_step, data)
 
-        last_step = self.production_run(last_step)
+        last_step = self.production_run(last_step, data)
 
-    def sampling_loop(self, initial_position: jnp.array, training=False) -> jnp.array:
+    def sampling_loop(self, initial_position: jnp.array, data: jnp.array, training=False) -> jnp.array:
         """
         One sampling loop that iterate through the local sampler and potentially the global sampler.
         If training is set to True, the loop will also train the normalizing flow model.
@@ -175,7 +176,7 @@ class Sampler():
             summary_mode = 'production'
 
         self.rng_keys_mcmc, positions, log_prob, local_acceptance = self.local_sampler(
-            self.rng_keys_mcmc, self.n_local_steps, initial_position
+            self.rng_keys_mcmc, self.n_local_steps, initial_position, data
         )
 
         self.summary[summary_mode]['chains'] = jnp.append(
@@ -243,6 +244,7 @@ class Sampler():
                 self.variables,
                 self.likelihood_vec,
                 positions[:, -1],
+                data,
             )
 
             self.summary[summary_mode]['chains'] = jnp.append(
@@ -260,7 +262,7 @@ class Sampler():
 
         return last_step
 
-    def local_sampler_tuning(self, initial_position: jnp.array, max_iter: int = 100):
+    def local_sampler_tuning(self, initial_position: jnp.array, data: jnp.array, max_iter: int = 100):
         """
         Tuning the local sampler. This runs a number of iterations of the local sampler,
         and then uses the acceptance rate to adjust the local sampler parameters.
@@ -274,15 +276,15 @@ class Sampler():
         """
         if self.local_autotune is not None:
             print("Autotune found, start tuning sampler_params")
-            kernel_vmap = jax.vmap(self.local_sampler_class.make_kernel(), in_axes = (0, 0, 0,  None), out_axes=(0, 0, 0))
-            self.local_sampler_class.params = self.local_autotune(
-                kernel_vmap, self.rng_keys_mcmc, initial_position, self.likelihood_vec(initial_position), self.local_sampler_class.params, max_iter)
-            self.local_sampler = self.local_sampler_class.make_sampler()
+            kernel_vmap = self.local_sampler.kernel_vmap
+            self.local_sampler.params = self.local_autotune(
+                kernel_vmap, self.rng_keys_mcmc, initial_position, self.likelihood_vec(initial_position), data, self.local_sampler.params, max_iter)
+            self.local_sampler = self.local_sampler.make_sampler()
 
         else:
             print("No autotune found, use input sampler_params")
 
-    def global_sampler_tuning(self, initial_position: jnp.ndarray) -> jnp.array:
+    def global_sampler_tuning(self, initial_position: jnp.ndarray, data: jnp.array) -> jnp.array:
         """
         Tuning the global sampler. This runs both the local sampler and the global sampler,
         and train the normalizing flow on the run.
@@ -300,10 +302,10 @@ class Sampler():
                 range(self.n_loop_training),
                 desc="Tuning global sampler",
                 ):
-            last_step = self.sampling_loop(last_step, training=True)
+            last_step = self.sampling_loop(last_step, data, training=True)
         return last_step
 
-    def production_run(self, initial_position: jnp.ndarray) -> jnp.array:
+    def production_run(self, initial_position: jnp.ndarray, data: jnp.array) -> jnp.array:
         """
         Sampling procedure that produce the final set of samples.
         The main difference between this and the global tuning step is
@@ -320,7 +322,7 @@ class Sampler():
                 range(self.n_loop_production),
                 desc="Production run",
                 ):
-            last_step = self.sampling_loop(last_step)
+            last_step = self.sampling_loop(last_step, data)
         return last_step
 
     def get_sampler_state(self, training: bool=False) -> dict:

--- a/test/integration/test_HMC.py
+++ b/test/integration/test_HMC.py
@@ -4,14 +4,16 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
-def dual_moon_pe(x):
+def dual_moon_pe(x, data):
     """
     Term 2 and 3 separate the distribution and smear it along the first and second dimension
     """
-    term1 = 0.5 * ((jnp.linalg.norm(x) - 2) / 0.1) ** 2
+    print("compile count")
+    term1 = 0.5 * ((jnp.linalg.norm(x-data) - 2) / 0.1) ** 2
     term2 = -0.5 * ((x[:1] + jnp.array([-3.0, 3.0])) / 0.8) ** 2
     term3 = -0.5 * ((x[1:2] + jnp.array([-3.0, 3.0])) / 0.6) ** 2
     return -(term1 - logsumexp(term2) - logsumexp(term3))
+
 
 n_dim = 5
 n_chains = 15
@@ -19,32 +21,27 @@ n_local_steps = 30
 step_size = 0.1
 n_leapfrog = 10
 
+data = jnp.arange(5)
+
 rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
 initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
 
 HMC = HMC(dual_moon_pe, True, {"step_size": step_size,"n_leapfrog": n_leapfrog, "inverse_metric": jnp.ones(n_dim)})
 
-initial_PE = jax.vmap(HMC.potential)(initial_position)
+initial_PE = HMC.logpdf_vmap(initial_position, data)
 
-HMC_kernel = HMC.make_kernel()
-
-print(HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], HMC.params))
-
-HMC_update = HMC.make_update()
-HMC_update = jax.vmap(HMC_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
+HMC.precompilation(n_chains, n_dim, n_local_steps, data)
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)
 initial_PE = jnp.repeat(initial_PE[:,None], n_local_steps, 1)
 
-state = (rng_key_set[1], initial_position, initial_PE, jnp.zeros((n_chains, n_local_steps,1)), HMC.params)
+state = (rng_key_set[1], initial_position, initial_PE, jnp.zeros((n_chains, n_local_steps,1)), data, HMC.params)
 
-
-HMC_update(1, state)
-
+HMC.update_vmap(1, state)
 HMC_sampler = HMC.make_sampler()
 
-state = HMC_sampler(rng_key_set[1], n_local_steps, initial_position[:, 0])
+state = HMC_sampler(rng_key_set[1], n_local_steps, initial_position[:, 0], data)
 
 
 from flowMC.nfmodel.rqSpline import RQSpline
@@ -69,9 +66,9 @@ print("Initializing sampler class")
 nf_sampler = Sampler(
     n_dim,
     rng_key_set,
+    jnp.arange(5),
     HMC,
-    dual_moon_pe,
-    model   ,
+    model,
     n_loop_training=n_loop_training,
     n_loop_production=n_loop_production,
     n_local_steps=n_local_steps,
@@ -80,4 +77,4 @@ nf_sampler = Sampler(
     use_global=False,
 )
 
-nf_sampler.sample(initial_position)
+nf_sampler.sample(initial_position, data)

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -25,7 +25,7 @@ initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 
 
 MALA_Sampler = MALA(dual_moon_pe, True, {"step_size": step_size})
 
-MALA_Sampler.precompilation(10, None)
+MALA_Sampler.precompilation(n_chains, n_dim, n_local_steps, None)
 
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
-def dual_moon_pe(x):
+def dual_moon_pe(x, data=None):
     """
     Term 2 and 3 separate the distribution and smear it along the first and second dimension
     """
@@ -29,19 +29,19 @@ MALA_Sampler_kernel = MALA_Sampler.make_kernel()
 
 
 MALA_Sampler_update = MALA_Sampler.make_update()
-MALA_Sampler_update = jax.vmap(MALA_Sampler_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
+MALA_Sampler_update = jax.vmap(MALA_Sampler_update, in_axes = (None, (0, 0, 0, 0, None, None)), out_axes=(0, 0, 0, 0, None, None))
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)
 initial_logp = jnp.repeat(jax.vmap(dual_moon_pe)(initial_position[:,0])[:,None], n_local_steps, 1)[...,None]
 
-state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), MALA_Sampler.params)
+state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), None, MALA_Sampler.params)
 
 
 MALA_Sampler_update(1, state)
 
 MALA_Sampler_sampler = MALA_Sampler.make_sampler()
 
-state = MALA_Sampler_sampler(rng_key_set[1], n_local_steps, initial_position[:,0])
+state = MALA_Sampler_sampler(rng_key_set[1], n_local_steps, initial_position[:,0], None)
 
 
 from flowMC.nfmodel.rqSpline import RQSpline

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -21,7 +21,7 @@ n_local_steps = 30
 step_size = 0.01
 n_leapfrog = 10
 
-data = jnp.array(np.random.normal(5))
+data = jnp.arange(5)
 
 rng_key_set = initialize_rng_keys(n_chains, seed=42)
 

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -8,6 +8,7 @@ def dual_moon_pe(x, data=None):
     """
     Term 2 and 3 separate the distribution and smear it along the first and second dimension
     """
+    print("compile count")
     term1 = 0.5 * ((jnp.linalg.norm(x) - 2) / 0.1) ** 2
     term2 = -0.5 * ((x[:1] + jnp.array([-3.0, 3.0])) / 0.8) ** 2
     term3 = -0.5 * ((x[1:2] + jnp.array([-3.0, 3.0])) / 0.6) ** 2
@@ -63,9 +64,9 @@ print("Initializing sampler class")
 nf_sampler = Sampler(
     n_dim,
     rng_key_set,
+    None,
     MALA_Sampler,
-    dual_moon_pe,
-    model   ,
+    model,
     n_loop_training=n_loop_training,
     n_loop_production=n_loop_production,
     n_local_steps=n_local_steps,
@@ -75,6 +76,5 @@ nf_sampler = Sampler(
     use_global=False,
 )
 
-nf_sampler.sample(initial_position)
+nf_sampler.sample(initial_position, None)
 
-mala_kernel_vmap = jax.vmap(MALA_Sampler_kernel, in_axes = (0, 0, 0,  None), out_axes=(0, 0, 0))

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -3,13 +3,14 @@ from flowMC.utils.PRNG_keys import initialize_rng_keys
 import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
+import numpy as np
 
-def dual_moon_pe(x, data=None):
+def dual_moon_pe(x, data):
     """
     Term 2 and 3 separate the distribution and smear it along the first and second dimension
     """
     print("compile count")
-    term1 = 0.5 * ((jnp.linalg.norm(x) - 2) / 0.1) ** 2
+    term1 = 0.5 * ((jnp.linalg.norm(x-data) - 2) / 0.1) ** 2
     term2 = -0.5 * ((x[:1] + jnp.array([-3.0, 3.0])) / 0.8) ** 2
     term3 = -0.5 * ((x[1:2] + jnp.array([-3.0, 3.0])) / 0.6) ** 2
     return -(term1 - logsumexp(term2) - logsumexp(term3))
@@ -20,26 +21,28 @@ n_local_steps = 30
 step_size = 0.01
 n_leapfrog = 10
 
+data = jnp.array(np.random.normal(5))
+
 rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
 initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
 
 MALA_Sampler = MALA(dual_moon_pe, True, {"step_size": step_size})
 
-MALA_Sampler.precompilation(n_chains, n_dim, n_local_steps, None)
+MALA_Sampler.precompilation(n_chains, n_dim, n_local_steps, data)
 
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)
-initial_logp = jnp.repeat(jax.vmap(dual_moon_pe)(initial_position[:,0])[:,None], n_local_steps, 1)[...,None]
+initial_logp = jnp.repeat(jax.vmap(dual_moon_pe, in_axes=(0,None))(initial_position[:,0], data)[:,None], n_local_steps, 1)[...,None]
 
-state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), None, MALA_Sampler.params)
+state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), data, MALA_Sampler.params)
 
 
 MALA_Sampler.update_vmap(1, state)
 
 MALA_Sampler_sampler = MALA_Sampler.make_sampler()
 
-state = MALA_Sampler_sampler(rng_key_set[1], n_local_steps, initial_position[:,0], None)
+state = MALA_Sampler_sampler(rng_key_set[1], n_local_steps, initial_position[:,0], data)
 
 
 from flowMC.nfmodel.rqSpline import RQSpline
@@ -64,7 +67,7 @@ print("Initializing sampler class")
 nf_sampler = Sampler(
     n_dim,
     rng_key_set,
-    None,
+    jnp.arange(5),
     MALA_Sampler,
     model,
     n_loop_training=n_loop_training,
@@ -76,5 +79,5 @@ nf_sampler = Sampler(
     use_global=False,
 )
 
-nf_sampler.sample(initial_position, None)
+nf_sampler.sample(initial_position, data)
 

--- a/test/integration/test_RWMCMC.py
+++ b/test/integration/test_RWMCMC.py
@@ -4,11 +4,12 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
-def dual_moon_pe(x):
+def dual_moon_pe(x, data):
     """
     Term 2 and 3 separate the distribution and smear it along the first and second dimension
     """
-    term1 = 0.5 * ((jnp.linalg.norm(x) - 2) / 0.1) ** 2
+    print("compile count")
+    term1 = 0.5 * ((jnp.linalg.norm(x-data) - 2) / 0.1) ** 2
     term2 = -0.5 * ((x[:1] + jnp.array([-3.0, 3.0])) / 0.8) ** 2
     term3 = -0.5 * ((x[1:2] + jnp.array([-3.0, 3.0])) / 0.6) ** 2
     return -(term1 - logsumexp(term2) - logsumexp(term3))
@@ -19,28 +20,26 @@ n_local_steps = 30
 step_size = 0.1
 n_leapfrog = 10
 
+data = jnp.arange(5)
+
 rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
 initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
 
 RWMCMC = GaussianRandomWalk(dual_moon_pe, True, {"step_size": step_size})
 
-RWMCMC_kernel = RWMCMC.make_kernel()
-
-
-RWMCMC_update = RWMCMC.make_update()
-RWMCMC_update = jax.vmap(RWMCMC_update, in_axes = (None, (0, 0, 0, 0, None)), out_axes=(0, 0, 0, 0, None))
+RWMCMC.precompilation(n_chains, n_dim, n_local_steps, data)
 
 initial_position = jnp.repeat(initial_position[:,None], n_local_steps, 1)
-initial_logp = jnp.repeat(jax.vmap(dual_moon_pe)(initial_position[:,0])[:,None], n_local_steps, 1)[...,None]
+initial_logp = jnp.repeat(jax.vmap(dual_moon_pe, in_axes=(0,None))(initial_position[:,0],data)[:,None], n_local_steps, 1)[...,None]
 
-state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), {"step_size": step_size})
+state = (rng_key_set[1], initial_position, initial_logp, jnp.zeros((n_chains, n_local_steps,1)), data, RWMCMC.params)
 
-RWMCMC_update(1, state)
+RWMCMC.update_vmap(1, state)
 
 RWMCMC_sampler = RWMCMC.make_sampler()
 
-state = RWMCMC_sampler(rng_key_set[1], n_local_steps, initial_position[:,0])
+state = RWMCMC_sampler(rng_key_set[1], n_local_steps, initial_position[:,0], data)
 
 
 from flowMC.nfmodel.rqSpline import RQSpline
@@ -65,9 +64,9 @@ print("Initializing sampler class")
 nf_sampler = Sampler(
     n_dim,
     rng_key_set,
+    data,
     RWMCMC,
-    dual_moon_pe,
-    model   ,
+    model,
     n_loop_training=n_loop_training,
     n_loop_production=n_loop_production,
     n_local_steps=n_local_steps,
@@ -76,4 +75,4 @@ nf_sampler = Sampler(
     use_global=False,
 )
 
-nf_sampler.sample(initial_position)
+nf_sampler.sample(initial_position, data)

--- a/test/integration/test_quickstart.py
+++ b/test/integration/test_quickstart.py
@@ -6,8 +6,10 @@ from flowMC.sampler.Sampler import Sampler
 from flowMC.utils.PRNG_keys import initialize_rng_keys
 from flowMC.nfmodel.utils import *
 
-def log_posterior(x):
-    return -0.5 * jnp.sum(x ** 2)
+def log_posterior(x, data):
+    return -0.5 * jnp.sum((x-data) ** 2)
+
+data = jnp.arange(5)
 
 n_dim = 5
 n_chains = 10
@@ -20,8 +22,8 @@ local_sampler = MALA(log_posterior, True, {"step_size": step_size})
 
 nf_sampler = Sampler(n_dim,
                     rng_key_set,
+                    jnp.arange(n_dim),
                     local_sampler,
-                    log_posterior,
                     model,
                     n_local_steps = 50,
                     n_global_steps = 50,
@@ -30,5 +32,5 @@ nf_sampler = Sampler(n_dim,
                     batch_size = 1000,
                     n_chains = n_chains)
 
-nf_sampler.sample(initial_position)
+nf_sampler.sample(initial_position, data)
 chains,log_prob,local_accs, global_accs = nf_sampler.get_sampler_state().values()

--- a/test/unit/test_kernels.py
+++ b/test/unit/test_kernels.py
@@ -1,11 +1,11 @@
 from flowMC.sampler.HMC import HMC
-from flowMC.sampler.MALA import MALA, mala_sampler_autotune
+from flowMC.sampler.MALA import MALA
 from flowMC.sampler.Gaussian_random_walk import GaussianRandomWalk
 from flowMC.utils.PRNG_keys import initialize_rng_keys
 import jax
 import jax.numpy as jnp
 
-def log_posterior(x):
+def log_posterior(x, data=None):
     return -0.5 * jnp.sum(x ** 2)
 
 class TestHMC:
@@ -18,14 +18,14 @@ class TestHMC:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-        initial_PE = jax.vmap(HMC_obj.potential)(initial_position)
+        initial_PE = jax.vmap(HMC_obj.potential)(initial_position, None)
 
         HMC_kernel, leapfrog_kernel, leapfrog_step = HMC_obj.make_kernel(return_aux=True)
 
         # Test whether the HMC kernel is deterministic
 
-        result1 = (HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], HMC_obj.params))
-        result2 = (HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], HMC_obj.params))
+        result1 = (HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], None, HMC_obj.params))
+        result2 = (HMC_kernel(rng_key_set[0], initial_position[0], initial_PE[0], None, HMC_obj.params))
 
         assert jnp.allclose(result1[0],result2[0])
         assert result1[1]==result2[1]
@@ -39,17 +39,17 @@ class TestHMC:
 
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-        initial_PE = jax.vmap(HMC_obj.potential)(initial_position)
+        initial_PE = jax.vmap(HMC_obj.potential, in_axes=(0,None))(initial_position, None)
 
         HMC_kernel, leapfrog_kernel, leapfrog_step = HMC_obj.make_kernel(return_aux=True)
         key1, key2 = jax.random.split(rng_key_set[0])
 
         initial_momentum = jax.random.normal(key1, shape=initial_position.shape) * jnp.ones(n_dim)**-0.5
-        new_position, new_momentum = leapfrog_step(initial_position, initial_momentum, HMC_obj.params)
-        rev_position, rev_momentum = leapfrog_step(new_position, -new_momentum, HMC_obj.params)
+        new_position, new_momentum = leapfrog_step(initial_position, initial_momentum, None, HMC_obj.params)
+        rev_position, rev_momentum = leapfrog_step(new_position, -new_momentum, None, HMC_obj.params)
 
         assert jnp.allclose(rev_position, initial_position)
-        assert jnp.allclose(initial_PE, HMC_obj.potential(rev_position))
+        assert jnp.allclose(initial_PE, HMC_obj.potential(rev_position, None))
 
     def test_HMC_acceptance_rate(self):
         # Test acceptance rate goes to one when step size is small
@@ -62,9 +62,9 @@ class TestHMC:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-        initial_PE = jax.vmap(HMC_obj.potential)(initial_position)
+        initial_PE = jax.vmap(HMC_obj.potential)(initial_position, None)
 
-        result = jax.vmap(HMC_kernel, in_axes = (0, 0, 0, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_PE, HMC_obj.params)
+        result = jax.vmap(HMC_kernel, in_axes = (0, 0, 0, None, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_PE, None, HMC_obj.params)
 
         assert result[2].all()
 
@@ -76,10 +76,10 @@ class TestHMC:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-
+        HMC_obj.precompilation(n_chains, n_dim, 10000, None)
         HMC_sampler = HMC_obj.make_sampler()
 
-        result = HMC_sampler(rng_key_set[1], 10000, initial_position)
+        result = HMC_sampler(rng_key_set[1], 10000, initial_position, None)
 
         assert jnp.isclose(jnp.mean(result[1]),0,atol=1e-2)
         assert jnp.isclose(jnp.var(result[1]),1,atol=1e-2)
@@ -95,7 +95,7 @@ class TestMALA:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-        initial_logp = log_posterior(initial_position)
+        initial_logp = log_posterior(initial_position, None)
 
         result1 = (MALA_kernel(rng_key_set[0], initial_position[0], initial_logp, MALA_obj.params))
         result2 = (MALA_kernel(rng_key_set[0], initial_position[0], initial_logp, MALA_obj.params))
@@ -115,9 +115,9 @@ class TestMALA:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-        initial_logp = jax.vmap(log_posterior)(initial_position)
+        initial_logp = jax.vmap(log_posterior)(initial_position, None)
 
-        result = jax.vmap(MALA_kernel, in_axes = (0, 0, 0, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_logp, MALA_obj.params)
+        result = jax.vmap(MALA_kernel, in_axes = (0, 0, 0, None, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_logp, None, MALA_obj.params)
 
         assert result[2].all()
 
@@ -129,10 +129,11 @@ class TestMALA:
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
+        MALA_obj.precompilation(n_chains, n_dim, 30000, None)
 
         MALA_sampler = MALA_obj.make_sampler()
 
-        result = MALA_sampler(rng_key_set[1], 30000, initial_position)
+        result = MALA_sampler(rng_key_set[1], 30000, initial_position, None)
 
         assert jnp.isclose(jnp.mean(result[1]),0,atol=1e-2)
         assert jnp.isclose(jnp.var(result[1]),1,atol=1e-2)
@@ -171,7 +172,7 @@ class TestGRW():
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
         initial_logp = jax.vmap(log_posterior)(initial_position)
 
-        result = jax.vmap(GRW_kernel, in_axes = (0, 0, 0, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_logp, GRW_obj.params)
+        result = jax.vmap(GRW_kernel, in_axes = (0, 0, 0, None, None), out_axes=(0, 0, 0))(rng_key_set[1], initial_position, initial_logp, None, GRW_obj.params)
 
         assert result[2].all()
 
@@ -183,10 +184,10 @@ class TestGRW():
         rng_key_set = initialize_rng_keys(n_chains, seed=42)
 
         initial_position = jax.random.normal(rng_key_set[0], shape=(n_chains, n_dim)) * 1
-
+        GRW_obj.precompilation(n_chains, n_dim, 30000, None)
         GRW_sampler = GRW_obj.make_sampler()
 
-        result = GRW_sampler(rng_key_set[1], 30000, initial_position)
+        result = GRW_sampler(rng_key_set[1], 30000, initial_position, None)
 
         assert jnp.isclose(jnp.mean(result[1]),0,atol=1e-2)
         assert jnp.isclose(jnp.var(result[1]),1,atol=1e-2)


### PR DESCRIPTION
In this PR we implemented a couple of functionailties:

1. Precompilation: Now the kernels and updates are constructed and compiled outside the make_xxx functions, inside a function `precompilation` in `LocalSampler_Base.py`. Previously there are multiple copies of likelihoods, kernels and update in the code, which bloated the compilation time. Now there should only be two compilation. This should address the concern in #111 
2. Moved autotune for MALA inside the MALA class. In previous version of the code, MALA autotune would makes its own vmap kernel, which would trigger recompilation. This is now handled properly so no recompilation should be needed.
3. Data batching. Now the sampler can take some additional data. This should address the concern in #93.

There are a couple more to-do items before we can merge this PR:

- [x] Modify random walk Gaussian
- [x] Modify HMC
- [ ] Update examples
- [ ] Update documentations
- [x] Update tests