### PR TITLE
153 use scan to reduce nf compilation time

### DIFF
--- a/src/flowMC/nfmodel/base.py
+++ b/src/flowMC/nfmodel/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, abstractproperty
 import equinox as eqx
-import jax
+from typing import overload, Optional
 from jaxtyping import Array, PRNGKeyArray, Float
 class NFModel(eqx.Module):
 
@@ -35,7 +35,7 @@ class NFModel(eqx.Module):
         return NotImplemented
 
     @abstractmethod
-    def forward(self, x: Float[Array, "n_dim"]) -> tuple[Float[Array, "n_dim"], Float]:
+    def forward(self, x: Float[Array, "n_dim"], key: Optional[PRNGKeyArray] = None) -> tuple[Float[Array, "n_dim"], Float]:
         """
         Forward pass of the model.
 
@@ -80,7 +80,7 @@ class Bijection(eqx.Module):
     def __init__(self):
         return NotImplemented
 
-    def __call__(self, x: Array) -> tuple[Array, Array]:
+    def __call__(self, x: Array, key: Optional[PRNGKeyArray] = None) -> tuple[Array, Array]:
         return self.forward(x)
 
     @abstractmethod
@@ -104,7 +104,7 @@ class Distribution(eqx.Module):
     def __init__(self):
         return NotImplemented
 
-    def __call__(self, x: Array) -> Array:
+    def __call__(self, x: Array, key: Optional[PRNGKeyArray] = None) -> Array:
         return self.log_prob(x)
 
     @abstractmethod

--- a/src/flowMC/nfmodel/rqSpline.py
+++ b/src/flowMC/nfmodel/rqSpline.py
@@ -110,8 +110,8 @@ def _rational_quadratic_spline_fwd(
     # If x is outside the spline range, we default to a linear transformation.
     y = jnp.where(below_range, (x - x_pos[0]) * knot_slopes[0] + y_pos[0], y)
     y = jnp.where(
-        above_range, (x - x_pos[-1]) * knot_slopes[-1] + y_pos[-1], y
-    )  # type: ignore
+        above_range, (x - x_pos[-1]) * knot_slopes[-1] + y_pos[-1], y   # type: ignore
+    )
     logdet = jnp.where(below_range, jnp.log(knot_slopes[0]), logdet)
     logdet = jnp.where(above_range, jnp.log(knot_slopes[-1]), logdet)
     return y, logdet
@@ -219,8 +219,8 @@ def _rational_quadratic_spline_inv(
     # If y is outside the spline range, we default to a linear transformation.
     x = jnp.where(below_range, (y - y_pos[0]) / knot_slopes[0] + x_pos[0], x)
     x = jnp.where(
-        above_range, (y - y_pos[-1]) / knot_slopes[-1] + x_pos[-1], x
-    )  # type: ignore
+        above_range, (y - y_pos[-1]) / knot_slopes[-1] + x_pos[-1], x # type: ignore
+    )
     logdet = jnp.where(below_range, -jnp.log(knot_slopes[0]), logdet)
     logdet = jnp.where(above_range, -jnp.log(knot_slopes[-1]), logdet)
     return x, logdet

--- a/src/flowMC/nfmodel/rqSpline.py
+++ b/src/flowMC/nfmodel/rqSpline.py
@@ -110,7 +110,7 @@ def _rational_quadratic_spline_fwd(
     # If x is outside the spline range, we default to a linear transformation.
     y = jnp.where(below_range, (x - x_pos[0]) * knot_slopes[0] + y_pos[0], y)
     y = jnp.where(
-        above_range, (x - x_pos[-1]) * knot_slopes[-1] + y_pos[-1], y   # type: ignore
+        above_range, (x - x_pos[-1]) * knot_slopes[-1] + y_pos[-1], y  # type: ignore
     )
     logdet = jnp.where(below_range, jnp.log(knot_slopes[0]), logdet)
     logdet = jnp.where(above_range, jnp.log(knot_slopes[-1]), logdet)
@@ -219,7 +219,7 @@ def _rational_quadratic_spline_inv(
     # If y is outside the spline range, we default to a linear transformation.
     x = jnp.where(below_range, (y - y_pos[0]) / knot_slopes[0] + x_pos[0], x)
     x = jnp.where(
-        above_range, (y - y_pos[-1]) / knot_slopes[-1] + x_pos[-1], x # type: ignore
+        above_range, (y - y_pos[-1]) / knot_slopes[-1] + x_pos[-1], x  # type: ignore
     )
     logdet = jnp.where(below_range, -jnp.log(knot_slopes[0]), logdet)
     logdet = jnp.where(above_range, -jnp.log(knot_slopes[-1]), logdet)
@@ -420,7 +420,7 @@ class MaskedCouplingRQSpline(NFModel):
             layer2 = MaskedCouplingLayer(
                 RQSpline(mlp, spline_range[0], spline_range[1]), mask
             )
-            return eqx.nn.Sequential([layer1, layer2]) # type: ignore
+            return eqx.nn.Sequential([layer1, layer2])  # type: ignore
 
         keys = jax.random.split(key, n_layers)
         self.layers = eqx.filter_vmap(make_layer)(jnp.arange(n_layers), keys)
@@ -435,14 +435,14 @@ class MaskedCouplingRQSpline(NFModel):
     ) -> tuple[Float[Array, " n_dim"], Float]:
         log_det = 0.0
         dynamics, statics = eqx.partition(self.layers, eqx.is_array)
-        
+
         def f(carry, data):
             x, log_det = carry
             layers = eqx.combine(data, statics)
             x, log_det_i = layers[0](x)
             log_det += log_det_i
             x, log_det_i = layers[1](x)
-            return (x, log_det+log_det_i), None
+            return (x, log_det + log_det_i), None
 
         (x, log_det), _ = jax.lax.scan(f, (x, log_det), dynamics)
         return x, log_det
@@ -454,14 +454,14 @@ class MaskedCouplingRQSpline(NFModel):
         """From latent space to data space"""
         log_det = 0.0
         dynamics, statics = eqx.partition(self.layers, eqx.is_array)
-        
+
         def f(carry, data):
             x, log_det = carry
             layers = eqx.combine(data, statics)
             x, log_det_i = layers[0].inverse(x)
             log_det += log_det_i
             x, log_det_i = layers[1].inverse(x)
-            return (x, log_det+log_det_i), None
+            return (x, log_det + log_det_i), None
 
         (x, log_det), _ = jax.lax.scan(f, (x, log_det), dynamics, reverse=True)
         return x, log_det

--- a/src/flowMC/nfmodel/rqSpline.py
+++ b/src/flowMC/nfmodel/rqSpline.py
@@ -406,30 +406,24 @@ class MaskedCouplingRQSpline(NFModel):
             self._data_cov = jnp.eye(n_features)
 
         self._n_features = n_features
-        conditioner = []
-        for i in range(n_layers):
-            key, conditioner_key = jax.random.split(key)
-            conditioner.append(
-                MLP(
-                    [n_features] + hidden_size + [n_features * (num_bins * 3 + 1)],
-                    conditioner_key,
-                    scale=1e-2,
-                    activation=jax.nn.tanh,
-                )
-            )
 
-        mask = (jnp.arange(0, n_features) % 2).astype(bool)
-        mask_all = (jnp.zeros(n_features)).astype(bool)
-        layers = []
-        for i in range(n_layers):
-            layers.append(MaskedCouplingLayer(ScalarAffine(0.0, 0.0), mask_all))
-            layers.append(
-                MaskedCouplingLayer(
-                    RQSpline(conditioner[i], spline_range[0], spline_range[1]), mask
-                )
+        def make_layer(i: int, key: PRNGKeyArray):
+            mlp = MLP(
+                [n_features] + hidden_size + [n_features * (num_bins * 3 + 1)],
+                key,
+                scale=1e-2,
+                activation=jax.nn.tanh,
             )
-            mask = jnp.logical_not(mask)
-        self.layers = layers
+            mask = ((jnp.arange(0, n_features) + i) % 2).astype(bool)
+            mask_all = (jnp.zeros(n_features)).astype(bool)
+            layer1 = MaskedCouplingLayer(ScalarAffine(0.0, 0.0), mask_all)
+            layer2 = MaskedCouplingLayer(
+                RQSpline(mlp, spline_range[0], spline_range[1]), mask
+            )
+            return eqx.nn.Sequential([eqx.nn.Lambda(layer1), eqx.nn.Lambda(layer2)])
+
+        keys = jax.random.split(key, n_layers)
+        self.layers = eqx.filter_vmap(make_layer)(jnp.arange(n_layers), keys)
 
     def __call__(
         self, x: Float[Array, " n_dim"]
@@ -440,9 +434,17 @@ class MaskedCouplingRQSpline(NFModel):
         self, x: Float[Array, " n_dim"]
     ) -> tuple[Float[Array, " n_dim"], Float]:
         log_det = 0.0
-        for layer in self.layers:
-            x, log_det_i = layer(x)
+        dynamics, statics = eqx.partition(self.layers, eqx.is_array)
+        
+        def f(carry, data):
+            x, log_det = carry
+            layers = eqx.combine(data, statics)
+            x, log_det_i = layers[0](x)
             log_det += log_det_i
+            x, log_det_i = layers[1](x)
+            return (x, log_det+log_det_i), None
+
+        (x, log_det), _ = jax.lax.scan(f, (x, log_det), dynamics)
         return x, log_det
 
     @partial(jax.vmap, in_axes=(None, 0))
@@ -451,6 +453,16 @@ class MaskedCouplingRQSpline(NFModel):
     ) -> tuple[Float[Array, " n_dim"], Float]:
         """From latent space to data space"""
         log_det = 0.0
+        dynamics, statics = eqx.partition(self.layers, eqx.is_array)
+        
+        def f(carry, data):
+            x, log_det = carry
+            layer = eqx.combine(data, statics)
+            x, log_det_i = layer(x)
+            return (x, log_det+log_det_i), None
+
+        (x, log_det), _ = jax.lax.scan(f, (x, log_det), dynamics)
+
         for layer in reversed(self.layers):
             x, log_det_i = layer.inverse(x)
             log_det += log_det_i

--- a/test/unit/test_nf.py
+++ b/test/unit/test_nf.py
@@ -24,7 +24,7 @@ def test_realnvp():
     n_features = 3
     n_hidden = 4
     n_layers = 2
-    x = jnp.array([[1, 2, 3], [4, 5, 6]])
+    x = jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
     rng_key, rng_subkey = jax.random.split(jax.random.PRNGKey(0), 2)
     model = RealNVP(n_features, n_layers, n_hidden, rng_key)
@@ -61,8 +61,6 @@ def test_rqspline():
     model = MaskedCouplingRQSpline(
         n_features, n_layers, hidden_layes, n_bins, jax.random.PRNGKey(10)
     )
-
-    jnp.array([[1, 2, 3], [4, 5, 6]])
 
     rng_key = jax.random.PRNGKey(0)
     samples = model.sample(rng_key, 2)


### PR DESCRIPTION
The forward and backward passes in both realNVP and RQSpline are both using scan.

