### PR TITLE
update example and add print summary to Sampler

### DIFF
--- a/example/dualmoon.py
+++ b/example/dualmoon.py
@@ -1,5 +1,6 @@
 import corner
 import jax
+print(jax.devices())
 import jax.numpy as jnp  # JAX NumPy
 import matplotlib.pyplot as plt
 import numpy as np
@@ -42,7 +43,7 @@ model = MaskedCouplingRQSpline(n_dim, 4, [32, 32], 8, subkey)
 rng_key, subkey = jax.random.split(rng_key)
 initial_position = jax.random.normal(subkey, shape=(n_chains, n_dim)) * 1
 
-MALA_Sampler = MALA(target_dualmoon, True, {"step_size": 0.1})
+MALA_Sampler = MALA(target_dualmoon, True, 0.1)
 
 print("Initializing sampler class")
 
@@ -80,7 +81,7 @@ print(
 )
 
 chains = np.array(chains)
-nf_samples = np.array(nf_samples[1])
+nf_samples = np.array(nf_samples)
 loss_vals = np.array(loss_vals)
 
 # Plot one chain to show the jump
@@ -123,3 +124,5 @@ figure = corner.corner(nf_samples, labels=["$x_1$", "$x_2$", "$x_3$", "$x_4$", "
 figure.set_size_inches(7, 7)
 figure.suptitle("Visualize NF samples")
 plt.show()
+
+nf_sampler.print_summary()

--- a/src/flowMC/Sampler.py
+++ b/src/flowMC/Sampler.py
@@ -388,3 +388,46 @@ class Sampler:
         """
         with open(path, "wb") as f:
             pickle.dump(self.summary, f)
+
+    def print_summary(self) -> None:
+        """
+        Print summary to the screen about log probabilities and local/global acceptance rates.
+        """
+        train_summary = self.get_sampler_state(training=True)
+        production_summary = self.get_sampler_state(training=False)
+
+        training_log_prob = train_summary["log_prob"]
+        training_local_acceptance = train_summary["local_accs"]
+        training_global_acceptance = train_summary["global_accs"]
+        training_loss = train_summary["loss_vals"]
+
+        production_log_prob = production_summary["log_prob"]
+        production_local_acceptance = production_summary["local_accs"]
+        production_global_acceptance = production_summary["global_accs"]
+
+        print("Training summary")
+        print("=" * 10)
+        print(
+            f"Log probability: {training_log_prob.mean():.3f} +/- {training_log_prob.std():.3f}"
+        )
+        print(
+            f"Local acceptance: {training_local_acceptance.mean():.3f} +/- {training_local_acceptance.std():.3f}"
+        )
+        print(
+            f"Global acceptance: {training_global_acceptance.mean():.3f} +/- {training_global_acceptance.std():.3f}"
+        )
+        print(
+            f"Max loss: {training_loss.max():.3f}, Min loss: {training_loss.min():.3f}"
+        )
+
+        print("Production summary")
+        print("=" * 10)
+        print(
+            f"Log probability: {production_log_prob.mean():.3f} +/- {production_log_prob.std():.3f}"
+        )
+        print(
+            f"Local acceptance: {production_local_acceptance.mean():.3f} +/- {production_local_acceptance.std():.3f}"
+        )
+        print(
+            f"Global acceptance: {production_global_acceptance.mean():.3f} +/- {production_global_acceptance.std():.3f}"
+        )


### PR DESCRIPTION
`dualmoon.py` now runs properly with the new flowMC version, and there is the possibility to print a diagnostic summary to the screen for the acceptance rates and log prob values. 