### PR TITLE
198 generalize buffer

### DIFF
--- a/docs/tutorials/custom_strategy.ipynb
+++ b/docs/tutorials/custom_strategy.ipynb
@@ -74,9 +74,9 @@
     "# Setting up resources\n",
     "\n",
     "RWMCMC_sampler = GaussianRandomWalk(step_size=step_size)\n",
-    "positions = Buffer(\"positions\", n_chains=n_chains, n_steps=n_steps, n_dims=n_dims)\n",
-    "log_prob = Buffer(\"log_prob\", n_chains=n_chains, n_steps=n_steps, n_dims=1)\n",
-    "acceptance = Buffer(\"acceptance\", n_chains=n_chains, n_steps=n_steps, n_dims=1)\n",
+    "positions = Buffer(\"positions\", (n_chains, n_steps, n_dims), 1)\n",
+    "log_prob = Buffer(\"log_prob\", (n_chains, n_steps), 1)\n",
+    "acceptance = Buffer(\"acceptance\", (n_chains, n_steps), 1)\n",
     "resource = {\n",
     "    \"positions\": positions,\n",
     "    \"log_prob\": log_prob,\n",
@@ -113,13 +113,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x7f0ab4166a50>"
+       "<matplotlib.colorbar.Colorbar at 0x7fc714262cf0>"
       ]
      },
      "execution_count": 3,
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +181,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x7f0a94677b10>"
+       "<matplotlib.collections.PathCollection at 0x7fc6f5f6bc50>"
       ]
      },
      "execution_count": 4,
@@ -212,9 +212,9 @@
     ")\n",
     "\n",
     "# Constructing the resources again.\n",
-    "positions = Buffer(\"positions\", n_chains=n_chains, n_steps=n_steps, n_dims=n_dims)\n",
-    "log_prob = Buffer(\"log_prob\", n_chains=n_chains, n_steps=n_steps, n_dims=1)\n",
-    "acceptance = Buffer(\"acceptance\", n_chains=n_chains, n_steps=n_steps, n_dims=1)\n",
+    "positions = Buffer(\"positions\", (n_chains, n_steps, n_dims), 1)\n",
+    "log_prob = Buffer(\"log_prob\", (n_chains, n_steps), 1)\n",
+    "acceptance = Buffer(\"acceptance\", (n_chains, n_steps), 1)\n",
     "resource = {\n",
     "    \"positions\": positions,\n",
     "    \"log_prob\": log_prob,\n",
@@ -275,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/dualmoon.ipynb
+++ b/docs/tutorials/dualmoon.ipynb
@@ -197,7 +197,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Tuning Phase: 100%|██████████| 20/20 [00:22<00:00,  1.15s/it]\n",
+      "Tuning Phase: 100%|██████████| 20/20 [00:21<00:00,  1.08s/it]\n",
       "Sampling Phase:   0%|          | 0/20 [00:00<?, ?it/s]"
      ]
     },
@@ -212,7 +212,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Sampling Phase: 100%|██████████| 20/20 [00:16<00:00,  1.18it/s]\n"
+      "Sampling Phase: 100%|██████████| 20/20 [00:05<00:00,  3.81it/s]\n"
      ]
     }
    ],
@@ -256,14 +256,14 @@
      "output_type": "stream",
      "text": [
       "Buffer positions_training with shape (20, 2200, 5)\n",
-      "Buffer log_prob_training with shape (20, 2200, 1)\n",
-      "Buffer local_accs_training with shape (20, 2200, 1)\n",
-      "Buffer global_accs_training with shape (20, 2200, 1)\n",
-      "Buffer loss_buffer with shape (1, 100, 1)\n",
+      "Buffer log_prob_training with shape (20, 2200)\n",
+      "Buffer local_accs_training with shape (20, 2200)\n",
+      "Buffer global_accs_training with shape (20, 2200)\n",
+      "Buffer loss_buffer with shape (100,)\n",
       "Buffer positions_production with shape (20, 2200, 5)\n",
-      "Buffer log_prob_production with shape (20, 2200, 1)\n",
-      "Buffer local_accs_production with shape (20, 2200, 1)\n",
-      "Buffer global_accs_production with shape (20, 2200, 1)\n",
+      "Buffer log_prob_production with shape (20, 2200)\n",
+      "Buffer local_accs_production with shape (20, 2200)\n",
+      "Buffer global_accs_production with shape (20, 2200)\n",
       "MALA with step size 0.1\n",
       "NF proposal with MaskedCouplingRQSpline with n_features=5, n_layers=2\n",
       "MaskedCouplingRQSpline with n_features=5, n_layers=2\n",
@@ -428,7 +428,7 @@
     "ax[1].set_title(\"Global acceptance rate\")\n",
     "ax[1].set_xlabel(\"Global steps\")\n",
     "# We are downsampling both the chain and the step dimension for a better visualization\n",
-    "ax[2].plot(log_prob[::5, ::20, 0].T, lw=1, alpha=0.5)\n",
+    "ax[2].plot(log_prob[::5, ::20].T, lw=1, alpha=0.5)\n",
     "ax[2].set_title(\"Log probability\")"
    ]
   },
@@ -449,7 +449,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f4354c278c0>"
+       "<matplotlib.legend.Legend at 0x7f1daa263a10>"
       ]
      },
      "execution_count": 8,

--- a/src/flowMC/resource/buffers.py
+++ b/src/flowMC/resource/buffers.py
@@ -29,7 +29,7 @@ class Buffer(Resource):
     def __call__(self):
         return self.data
 
-    def update_buffer(self, updates: Array):
+    def update_buffer(self, updates: Array, start: int = 0):
         """Update the buffer with new data.
 
         This will modify the buffer in place.
@@ -37,9 +37,8 @@ class Buffer(Resource):
         with length equal to the length of the updates in its first dimension.
         """
         self.data = jax.lax.dynamic_update_slice_in_dim(
-            self.data, updates, self.cursor, self.cursor_dim
+            self.data, updates, start, self.cursor_dim
         )
-        self.cursor = self.cursor + updates.shape[0]
 
 
     def print_parameters(self):

--- a/src/flowMC/resource/buffers.py
+++ b/src/flowMC/resource/buffers.py
@@ -40,7 +40,6 @@ class Buffer(Resource):
             self.data, updates, start, self.cursor_dim
         )
 
-
     def print_parameters(self):
         print(
             f"Buffer: {self.name} with shape {self.data.shape} and cursor"

--- a/src/flowMC/resource_strategy_bundles.py
+++ b/src/flowMC/resource_strategy_bundles.py
@@ -68,28 +68,28 @@ class RQSpline_MALA_Bundle(ResourceStrategyBundle):
         n_total_epochs = n_training_loops * n_epochs
 
         positions_training = Buffer(
-            "positions_training", n_chains, n_training_steps, n_dim
+            "positions_training", (n_chains, n_training_steps, n_dim), 1
         )
-        log_prob_training = Buffer("log_prob_training", n_chains, n_training_steps, 1)
+        log_prob_training = Buffer("log_prob_training", (n_chains, n_training_steps), 1)
         local_accs_training = Buffer(
-            "local_accs_training", n_chains, n_training_steps, 1
+            "local_accs_training", (n_chains, n_training_steps), 1
         )
         global_accs_training = Buffer(
-            "global_accs_training", n_chains, n_training_steps, 1
+            "global_accs_training", (n_chains, n_training_steps), 1
         )
-        loss_buffer = Buffer("loss_buffer", 1, n_total_epochs, 1)
+        loss_buffer = Buffer("loss_buffer", (n_total_epochs,), 0)
 
         position_production = Buffer(
-            "positions_production", n_chains, n_production_steps, n_dim
+            "positions_production", (n_chains, n_production_steps, n_dim), 1
         )
         log_prob_production = Buffer(
-            "log_prob_production", n_chains, n_production_steps, 1
+            "log_prob_production", (n_chains, n_production_steps), 1
         )
         local_accs_production = Buffer(
-            "local_accs_production", n_chains, n_production_steps, 1
+            "local_accs_production", (n_chains, n_production_steps), 1
         )
         global_accs_production = Buffer(
-            "global_accs_production", n_chains, n_production_steps, 1
+            "global_accs_production", (n_chains, n_production_steps), 1
         )
 
         local_sampler = MALA(step_size=mala_step_size)

--- a/src/flowMC/strategy/take_steps.py
+++ b/src/flowMC/strategy/take_steps.py
@@ -89,9 +89,9 @@ class TakeSteps(Strategy):
         log_probs = log_probs[:, :: self.thinning]
         do_accepts = do_accepts[:, :: self.thinning].astype(jnp.float32)
 
-        position_buffer.update_buffer(positions)
-        log_prob_buffer.update_buffer(log_probs)
-        acceptance_buffer.update_buffer(do_accepts)
+        position_buffer.update_buffer(positions, self.current_position)
+        log_prob_buffer.update_buffer(log_probs, self.current_position)
+        acceptance_buffer.update_buffer(do_accepts, self.current_position)
         self.current_position += self.n_steps // self.thinning
         return rng_key, resources, positions[:, -1]
 

--- a/src/flowMC/strategy/take_steps.py
+++ b/src/flowMC/strategy/take_steps.py
@@ -4,6 +4,7 @@ from flowMC.resource.buffers import Buffer
 from flowMC.strategy.base import Strategy
 from jaxtyping import Array, Float, PRNGKeyArray
 import jax
+import jax.numpy as jnp
 import equinox as eqx
 from typing import Callable
 from abc import abstractmethod
@@ -85,18 +86,12 @@ class TakeSteps(Strategy):
         )(subkey, initial_position, data)
 
         positions = positions[:, :: self.thinning]
-        log_probs = log_probs[:, :: self.thinning][..., None]
-        do_accepts = do_accepts[:, :: self.thinning][..., None]
+        log_probs = log_probs[:, :: self.thinning]
+        do_accepts = do_accepts[:, :: self.thinning].astype(jnp.float32)
 
-        position_buffer.update_buffer(
-            positions, self.n_steps // self.thinning, self.current_position
-        )
-        log_prob_buffer.update_buffer(
-            log_probs, self.n_steps // self.thinning, self.current_position
-        )
-        acceptance_buffer.update_buffer(
-            do_accepts, self.n_steps // self.thinning, self.current_position
-        )
+        position_buffer.update_buffer(positions)
+        log_prob_buffer.update_buffer(log_probs)
+        acceptance_buffer.update_buffer(do_accepts)
         self.current_position += self.n_steps // self.thinning
         return rng_key, resources, positions[:, -1]
 

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -100,7 +100,7 @@ class TrainModel(Strategy):
                 loss_buffer, Buffer
             ), "Loss buffer resource must be a buffer"
             loss_buffer.update_buffer(
-                loss_values,
+                loss_values, start=loss_buffer.cursor
             )
             loss_buffer.cursor += len(loss_values)
             resources[self.loss_buffer_name] = loss_buffer

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -99,9 +99,7 @@ class TrainModel(Strategy):
             assert isinstance(
                 loss_buffer, Buffer
             ), "Loss buffer resource must be a buffer"
-            loss_buffer.update_buffer(
-                loss_values, start=loss_buffer.cursor
-            )
+            loss_buffer.update_buffer(loss_values, start=loss_buffer.cursor)
             loss_buffer.cursor += len(loss_values)
             resources[self.loss_buffer_name] = loss_buffer
 

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -63,7 +63,7 @@ class TrainModel(Strategy):
         assert isinstance(
             optimizer, Optimizer
         ), "Optimizer resource must be an optimizer"
-        training_data = data_resource.data.reshape(-1, data_resource.n_dims)[
+        training_data = data_resource.data.reshape(-1, data_resource.shape[-1])[
             :: self.thinning
         ]
         training_data = training_data[jnp.isfinite(training_data).all(axis=1)]
@@ -100,9 +100,7 @@ class TrainModel(Strategy):
                 loss_buffer, Buffer
             ), "Loss buffer resource must be a buffer"
             loss_buffer.update_buffer(
-                jnp.array(loss_values)[None, :, None],
-                len(loss_values),
-                start=loss_buffer.cursor,
+                loss_values,
             )
             loss_buffer.cursor += len(loss_values)
             resources[self.loss_buffer_name] = loss_buffer

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -102,9 +102,9 @@ class TrainModel(Strategy):
             loss_buffer.update_buffer(
                 jnp.array(loss_values)[None, :, None],
                 len(loss_values),
-                start=loss_buffer.current_position,
+                start=loss_buffer.cursor,
             )
-            loss_buffer.current_position += len(loss_values)
+            loss_buffer.cursor += len(loss_values)
             resources[self.loss_buffer_name] = loss_buffer
 
         optimizer.optim_state = optim_state

--- a/test/integration/test_HMC.py
+++ b/test/integration/test_HMC.py
@@ -9,7 +9,7 @@ from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler
 
 
-def dual_moon_pe(x: Float[Array, "n_dim"], data: dict):
+def dual_moon_pe(x: Float[Array, " n_dims"], data: dict):
     """
     Term 2 and 3 separate the distribution
     and smear it along the first and second dimension
@@ -22,7 +22,7 @@ def dual_moon_pe(x: Float[Array, "n_dim"], data: dict):
 
 
 # Setup parameters
-n_dim = 5
+n_dims = 5
 n_chains = 15
 n_local_steps = 30
 step_size = 0.1
@@ -33,18 +33,18 @@ data = {"data": jnp.arange(5)}
 # Initialize positions
 rng_key = jax.random.PRNGKey(42)
 rng_key, subkey = jax.random.split(rng_key)
-initial_position = jax.random.normal(subkey, shape=(n_chains, n_dim)) * 1
+initial_position = jax.random.normal(subkey, shape=(n_chains, n_dims)) * 1
 
 # Define resources
 HMC_sampler = HMC(
     step_size=step_size,
     n_leapfrog=n_leapfrog,
-    condition_matrix=jnp.eye(n_dim),
+    condition_matrix=jnp.eye(n_dims),
 )
 
-positions = Buffer("positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dim)
-log_prob = Buffer("log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
-acceptance = Buffer("acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
+positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
 resource = {
     "positions": positions,
@@ -63,7 +63,7 @@ strategy = TakeSerialSteps(
 
 # Initialize and run sampler
 nf_sampler = Sampler(
-    n_dim=n_dim,
+    n_dim=n_dims,
     n_chains=n_chains,
     rng_key=rng_key,
     resources=resource,

--- a/test/integration/test_MALA.py
+++ b/test/integration/test_MALA.py
@@ -35,9 +35,9 @@ initial_position = jax.random.normal(subkey, shape=(n_chains, n_dims)) * 1
 # Defining resources
 
 MALA_Sampler = MALA(step_size=step_size)
-positions = Buffer("positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dims)
-log_prob = Buffer("log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
-acceptance = Buffer("acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
+positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
 resource = {
     "positions": positions,

--- a/test/integration/test_RWMCMC.py
+++ b/test/integration/test_RWMCMC.py
@@ -9,7 +9,7 @@ from flowMC.resource.buffers import Buffer
 from flowMC.Sampler import Sampler
 
 
-def dual_moon_pe(x: Float[Array, "n_dim"], data: dict):
+def dual_moon_pe(x: Float[Array, " n_dims"], data: dict):
     """
     Term 2 and 3 separate the distribution
     and smear it along the first and second dimension
@@ -22,7 +22,7 @@ def dual_moon_pe(x: Float[Array, "n_dim"], data: dict):
 
 
 # Test parameters
-n_dim = 5
+n_dims = 5
 n_chains = 2
 n_local_steps = 3
 n_global_steps = 3
@@ -33,13 +33,13 @@ data = {"data": jnp.arange(5)}
 # Initialize random key and position
 rng_key = jax.random.PRNGKey(43)
 rng_key, subkey = jax.random.split(rng_key)
-initial_position = jax.random.normal(subkey, shape=(n_chains, n_dim)) * 1
+initial_position = jax.random.normal(subkey, shape=(n_chains, n_dims)) * 1
 
 # Define resources
 RWMCMC_sampler = GaussianRandomWalk(step_size=step_size)
-positions = Buffer("positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dim)
-log_prob = Buffer("log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
-acceptance = Buffer("acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1)
+positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
 # Initialize normalizing flow model
 rng_key, subkey = jax.random.split(rng_key)
@@ -63,7 +63,7 @@ print("Initializing sampler class")
 
 # Initialize and run sampler
 nf_sampler = Sampler(
-    n_dim=n_dim,
+    n_dim=n_dims,
     n_chains=n_chains,
     rng_key=rng_key,
     resources=resource,

--- a/test/unit/test_kernels.py
+++ b/test/unit/test_kernels.py
@@ -331,15 +331,9 @@ class TestGRW:
         n_local_steps = 50000
         GRW_Sampler = GaussianRandomWalk(step_size=1)
 
-        positions = Buffer(
-            "positions", (n_chains, n_local_steps, n_dims), 1
-        )
-        log_prob = Buffer(
-            "log_prob", (n_chains, n_local_steps), 1
-        )
-        acceptance = Buffer(
-            "acceptance", (n_chains, n_local_steps), 1
-        )
+        positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+        log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+        acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
         resource = {
             "positions": positions,

--- a/test/unit/test_kernels.py
+++ b/test/unit/test_kernels.py
@@ -142,15 +142,9 @@ class TestHMC:
             n_leapfrog=5,
             condition_matrix=jnp.eye(n_dims),
         )
-        positions = Buffer(
-            "positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dims
-        )
-        log_prob = Buffer(
-            "log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
-        )
-        acceptance = Buffer(
-            "acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
-        )
+        positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+        log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+        acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
         resource = {
             "positions": positions,
@@ -243,15 +237,9 @@ class TestMALA:
         n_chains = 1
         n_local_steps = 50000
         MALA_Sampler = MALA(step_size=1)
-        positions = Buffer(
-            "positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dims
-        )
-        log_prob = Buffer(
-            "log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
-        )
-        acceptance = Buffer(
-            "acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
-        )
+        positions = Buffer("positions", (n_chains, n_local_steps, n_dims), 1)
+        log_prob = Buffer("log_prob", (n_chains, n_local_steps), 1)
+        acceptance = Buffer("acceptance", (n_chains, n_local_steps), 1)
 
         resource = {
             "positions": positions,
@@ -344,13 +332,13 @@ class TestGRW:
         GRW_Sampler = GaussianRandomWalk(step_size=1)
 
         positions = Buffer(
-            "positions", n_chains=n_chains, n_steps=n_local_steps, n_dims=n_dims
+            "positions", (n_chains, n_local_steps, n_dims), 1
         )
         log_prob = Buffer(
-            "log_prob", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
+            "log_prob", (n_chains, n_local_steps), 1
         )
         acceptance = Buffer(
-            "acceptance", n_chains=n_chains, n_steps=n_local_steps, n_dims=1
+            "acceptance", (n_chains, n_local_steps), 1
         )
 
         resource = {

--- a/test/unit/test_resources.py
+++ b/test/unit/test_resources.py
@@ -10,7 +10,7 @@ class TestBuffer:
         assert buffer.cursor_dim == 1
 
     def test_update_buffer(self):
-        buffer = Buffer("test", (10, 10), cursor_dim=1)
-        buffer.update_buffer(jnp.ones((1, 10, 10)))
-        assert buffer.cursor == 1
-        assert buffer.data[0] == jnp.ones((10, 10))
+        buffer = Buffer("test", (10, 10), cursor_dim=0)
+        buffer.update_buffer(jnp.ones((10, 10)))
+        assert buffer.cursor == 10
+        assert (buffer.data == jnp.ones((10, 10))).all()

--- a/test/unit/test_resources.py
+++ b/test/unit/test_resources.py
@@ -12,5 +12,4 @@ class TestBuffer:
     def test_update_buffer(self):
         buffer = Buffer("test", (10, 10), cursor_dim=0)
         buffer.update_buffer(jnp.ones((10, 10)))
-        assert buffer.cursor == 10
         assert (buffer.data == jnp.ones((10, 10))).all()

--- a/test/unit/test_resources.py
+++ b/test/unit/test_resources.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 from flowMC.resource.buffers import Buffer
 
+
 class TestBuffer:
     def test_buffer(self):
         buffer = Buffer("test", (10, 10), cursor_dim=1)

--- a/test/unit/test_resources.py
+++ b/test/unit/test_resources.py
@@ -1,0 +1,16 @@
+import jax.numpy as jnp
+from flowMC.resource.buffers import Buffer
+
+class TestBuffer:
+    def test_buffer(self):
+        buffer = Buffer("test", (10, 10), cursor_dim=1)
+        assert buffer.name == "test"
+        assert buffer.data.shape == (10, 10)
+        assert buffer.cursor == 0
+        assert buffer.cursor_dim == 1
+
+    def test_update_buffer(self):
+        buffer = Buffer("test", (10, 10), cursor_dim=1)
+        buffer.update_buffer(jnp.ones((1, 10, 10)))
+        assert buffer.cursor == 1
+        assert buffer.data[0] == jnp.ones((10, 10))

--- a/test/unit/test_strategies.py
+++ b/test/unit/test_strategies.py
@@ -76,9 +76,9 @@ class TestStrategies:
         n_dims = 2
         n_batch = 5
 
-        test_position = Buffer("test_position", n_chains, n_steps, n_dims)
-        test_log_prob = Buffer("test_log_prob", n_chains, n_steps, 1)
-        test_acceptance = Buffer("test_acceptance", n_chains, n_steps, 1)
+        test_position = Buffer("test_position", (n_chains, n_steps, n_dims), 1)
+        test_log_prob = Buffer("test_log_prob", (n_chains, n_steps), 1)
+        test_acceptance = Buffer("test_acceptance", (n_chains, n_steps), 1)
 
         mala_kernel = MALA(1.0)
         grw_kernel = GaussianRandomWalk(1.0)
@@ -93,9 +93,6 @@ class TestStrategies:
             "HMC": hmc_kernel,
         }
 
-        test_log_prob.update_buffer(
-            log_posterior(jnp.zeros((n_chains, n_steps, 1))), n_steps
-        )
         strategy = TakeSerialSteps(
             log_posterior,
             "MALA",
@@ -164,12 +161,11 @@ class TestNFStrategies:
             jax.random.PRNGKey(10),
         )
 
-        test_data = Buffer("test_data", self.n_chains, self.n_steps, self.n_dims)
+        test_data = Buffer("test_data", (self.n_chains, self.n_steps, self.n_dims), 1)
         test_data.update_buffer(
             jax.random.normal(
                 rng_subkey, shape=(self.n_chains, self.n_steps, self.n_dims)
             ),
-            self.n_steps,
         )
         optimizer = Optimizer(model)
 
@@ -204,10 +200,10 @@ class TestNFStrategies:
 
     def test_take_NF_step(self):
         test_position = Buffer(
-            "test_position", self.n_chains, self.n_steps, self.n_dims
+            "test_position", (self.n_chains, self.n_steps, self.n_dims), 1
         )
-        test_log_prob = Buffer("test_log_prob", self.n_chains, self.n_steps, 1)
-        test_acceptance = Buffer("test_acceptance", self.n_chains, self.n_steps, 1)
+        test_log_prob = Buffer("test_log_prob", (self.n_chains, self.n_steps), 1)
+        test_acceptance = Buffer("test_acceptance", (self.n_chains, self.n_steps), 1)
 
         model = MaskedCouplingRQSpline(
             self.n_features,
@@ -247,9 +243,9 @@ class TestNFStrategies:
         print(test_position.data[:, :, 0])
 
     def test_training_effect(self):
-        Buffer("test_position", self.n_chains, self.n_steps, self.n_dims)
-        Buffer("test_log_prob", self.n_chains, self.n_steps, 1)
-        Buffer("test_acceptance", self.n_chains, self.n_steps, 1)
+        Buffer("test_position", (self.n_chains, self.n_steps, self.n_dims), 1)
+        Buffer("test_log_prob", (self.n_chains, self.n_steps), 1)
+        Buffer("test_acceptance", (self.n_chains, self.n_steps), 1)
 
         model = MaskedCouplingRQSpline(
             self.n_features,


### PR DESCRIPTION
`Buffer` now takes general shapes instead of prefixed shape. 

**The following summary is generated by copilot**

This pull request includes significant updates to the `Buffer` class and its usage across various files, as well as modifications to tutorial notebooks to reflect these changes. The key changes focus on refactoring the `Buffer` class to improve flexibility, updating resource initialization, and adjusting test cases accordingly.

### Buffer Class Refactor:
* [`src/flowMC/resource/buffers.py`](diffhunk://#diff-ee201b6bbf1e02c55e90f89c75d65c8a318ee4a17efaa721fbd9d3c268f91194R6-L47): Refactored the `Buffer` class to use a more flexible shape definition, replaced `current_position` with `cursor`, and added `cursor_dim` for dimension-specific cursor tracking. Updated `update_buffer` method to use `jax.lax.dynamic_update_slice_in_dim`. [[1]](diffhunk://#diff-ee201b6bbf1e02c55e90f89c75d65c8a318ee4a17efaa721fbd9d3c268f91194R6-L47) [[2]](diffhunk://#diff-ee201b6bbf1e02c55e90f89c75d65c8a318ee4a17efaa721fbd9d3c268f91194L59-R62)

### Resource Initialization Updates:
* [`src/flowMC/resource_strategy_bundles.py`](diffhunk://#diff-14efcc35c4da4367dfd42ddfd9c2f00dacf9b0f11c5c038798cad99ecb5680e3L71-R92): Updated the initialization of `Buffer` instances to use the new shape and cursor_dim parameters.
* [`src/flowMC/strategy/take_steps.py`](diffhunk://#diff-a119cd150a9cdaf0210e01c468b4885163303a8ce1aa68ecc023f52bda04da73L88-R94): Adjusted the `__call__` method to use the updated `Buffer` class and removed unnecessary dimensions from `log_probs` and `do_accepts`.
* [`src/flowMC/strategy/train_model.py`](diffhunk://#diff-179fa5500d1430af4d8a81b736a5176d12147d49683114259dab55292b18352fL102-R103): Modified the `__call__` method to update the `loss_buffer` using the new cursor attribute.

### Tutorial Notebook Updates:
* [`docs/tutorials/custom_strategy.ipynb`](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL77-R79): Changed `Buffer` initialization to use the new shape and cursor_dim parameters, and updated execution counts for cells. [[1]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL77-R79) [[2]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL116-R122) [[3]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL170-R170) [[4]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL184-R184) [[5]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL215-R217) [[6]](diffhunk://#diff-dbf11b2b286cf53e4517e4435ef947a826ba650a3bbafbedaee4fa3cce6a12adL278-R278)
* [`docs/tutorials/dualmoon.ipynb`](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL200-R200): Updated `Buffer` initialization and modified text outputs to reflect performance improvements. [[1]](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL200-R200) [[2]](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL215-R215) [[3]](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL259-R266) [[4]](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL431-R431) [[5]](diffhunk://#diff-f00ec98eedac1a5656ccf40d6f3a151f9658431254d5f69b3727e6471610391eL452-R452)

### Test Case Adjustments:
* [`test/integration/test_HMC.py`](diffhunk://#diff-55d5af62bde34f7b33bddf6df719189c3fb1055a8dc8afdcc92c0cc85c84232cL12-R12): Refactored test cases to use the updated `Buffer` class and renamed `n_dim` to `n_dims`. [[1]](diffhunk://#diff-55d5af62bde34f7b33bddf6df719189c3fb1055a8dc8afdcc92c0cc85c84232cL12-R12) [[2]](diffhunk://#diff-55d5af62bde34f7b33bddf6df719189c3fb1055a8dc8afdcc92c0cc85c84232cL25-R25) [[3]](diffhunk://#diff-55d5af62bde34f7b33bddf6df719189c3fb1055a8dc8afdcc92c0cc85c84232cL36-R47) [[4]](diffhunk://#diff-55d5af62bde34f7b33bddf6df719189c3fb1055a8dc8afdcc92c0cc85c84232cL66-R66)
* [`test/integration/test_MALA.py`](diffhunk://#diff-2319bef02e701533fc4cb3d3a148c37c38170974ca8b07014b05992f1bd5468dL38-R40): Updated `Buffer` initialization in test cases.
* [`test/integration/test_RWMCMC.py`](diffhunk://#diff-b756d3effee0255255f7023cea3e30671f86e4aa3816082f5694020068a28b8bL12-R12): Refactored test cases to use the updated `Buffer` class and renamed `n_dim` to `n_dims`. [[1]](diffhunk://#diff-b756d3effee0255255f7023cea3e30671f86e4aa3816082f5694020068a28b8bL12-R12) [[2]](diffhunk://#diff-b756d3effee0255255f7023cea3e30671f86e4aa3816082f5694020068a28b8bL25-R25) [[3]](diffhunk://#diff-b756d3effee0255255f7023cea3e30671f86e4aa3816082f5694020068a28b8bL36-R42) [[4]](diffhunk://#diff-b756d3effee0255255f7023cea3e30671f86e4aa3816082f5694020068a28b8bL66-R66)