### PR TITLE
Add more flexible casting instead of fixing float32

### DIFF
--- a/src/flowMC/strategy/take_steps.py
+++ b/src/flowMC/strategy/take_steps.py
@@ -89,7 +89,7 @@ class TakeSteps(Strategy):
 
         positions = positions[:, :: self.thinning]
         log_probs = log_probs[:, :: self.thinning]
-        do_accepts = do_accepts[:, :: self.thinning].astype(jnp.float32)
+        do_accepts = do_accepts[:, :: self.thinning].astype(jnp.floating)
 
         position_buffer.update_buffer(positions, self.current_position)
         log_prob_buffer.update_buffer(log_probs, self.current_position)


### PR DESCRIPTION
This pull request includes a small change to the `src/flowMC/strategy/take_steps.py` file. The change updates the data type conversion for the `do_accepts` array to use `jnp.floating` instead of `jnp.float32`.

* [`src/flowMC/strategy/take_steps.py`](diffhunk://#diff-a119cd150a9cdaf0210e01c468b4885163303a8ce1aa68ecc023f52bda04da73L92-R92): Changed the data type conversion for `do_accepts` from `jnp.float32` to `jnp.floating`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal numerical data conversion to a more flexible format, ensuring consistent processing while keeping overall functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->