### PR TITLE
Jim sync

### DIFF
--- a/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
+++ b/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
@@ -331,7 +331,6 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
 
         strategy_order.append("reset_steppers")
         strategy_order.append("update_state")
-        strategy_order.append("initialize_tempered_positions")
         for _ in range(n_production_loops):
             strategy_order.extend(production_phase)
 

--- a/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
+++ b/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
@@ -319,11 +319,11 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
             "update_local_step",
         ]
         production_phase = [
-            "parallel_tempering",
             "local_stepper",
             "update_global_step",
             "global_stepper",
             "update_local_step",
+            "parallel_tempering",
         ]
         strategy_order = ["initialize_tempered_positions"]
         for _ in range(n_training_loops):

--- a/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
+++ b/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
@@ -57,11 +57,12 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
         local_thinning: int = 1,
         global_thinning: int = 1,
         n_flow_sample: int = 10000,
-        verbose: bool = False,
+        history_window: int = 100,
         n_temperatures: int = 5,
         max_temperature: float = 5.0,
         n_tempered_steps: int = -1,
         logprior: Callable[[Float[Array, " n_dim"], dict], Float] = lambda x, _: 0.0,
+        verbose: bool = False,
     ):
         n_training_steps = (
             n_local_steps * n_training_loops + n_global_steps * n_training_loops
@@ -181,6 +182,7 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
             n_epochs=n_epochs,
             batch_size=batch_size,
             n_max_examples=n_max_examples,
+            history_window=history_window,
             verbose=verbose,
         )
 
@@ -308,18 +310,18 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
         }
 
         training_phase = [
+            "parallel_tempering",
             "local_stepper",
             "update_global_step",
-            "parallel_tempering",
             "model_trainer",
             "update_model",
             "global_stepper",
             "update_local_step",
         ]
         production_phase = [
+            "parallel_tempering",
             "local_stepper",
             "update_global_step",
-            "parallel_tempering",
             "global_stepper",
             "update_local_step",
         ]

--- a/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
+++ b/src/flowMC/resource_strategy_bundle/RQSpline_MALA_PT.py
@@ -331,6 +331,7 @@ class RQSpline_MALA_PT_Bundle(ResourceStrategyBundle):
 
         strategy_order.append("reset_steppers")
         strategy_order.append("update_state")
+        strategy_order.append("initialize_tempered_positions")
         for _ in range(n_production_loops):
             strategy_order.extend(production_phase)
 

--- a/src/flowMC/strategy/parallel_tempering.py
+++ b/src/flowMC/strategy/parallel_tempering.py
@@ -317,7 +317,7 @@ class ParallelTempering(Strategy):
         ratio = (1.0 / temperatures[idx + 1] - 1.0 / temperatures[idx]) * (
             log_probs[idx] - log_probs[idx + 1]
         )
-        jax.debug.print("ratio: {}, idx: {}, idx+1:{}, temperature: {}, temperature+1: {}", ratio, log_probs[idx], log_probs[idx+1], temperatures[idx], temperatures[idx+1])
+        #jax.debug.print("ratio: {}, idx: {}, idx+1:{}, temperature: {}, temperature+1: {}", ratio, log_probs[idx], log_probs[idx+1], temperatures[idx], temperatures[idx+1])
         log_uniform = jnp.log(jax.random.uniform(subkey))
         do_accept: Bool[Array, " 1"] = log_uniform < ratio
         swapped = jnp.flip(jax.lax.dynamic_slice_in_dim(positions, idx, 2, axis=0))

--- a/src/flowMC/strategy/parallel_tempering.py
+++ b/src/flowMC/strategy/parallel_tempering.py
@@ -409,7 +409,8 @@ class ParallelTempering(Strategy):
         for i in range(1, temperatures.shape[0] - 1):
             new_temperatures = new_temperatures.at[i].set(
                 new_temperatures[i - 1]
-                + (temperatures[i] - temperatures[i - 1]) * jnp.exp(damping_factor[i])
+                + (temperatures[i] - temperatures[i - 1]) * jnp.exp(damping_factor[i-1])
             )
 
+        # jax.debug.print("{} {} {} {}", temperatures, acceptance_rate, damping_factor, new_temperatures )
         return new_temperatures

--- a/src/flowMC/strategy/parallel_tempering.py
+++ b/src/flowMC/strategy/parallel_tempering.py
@@ -105,13 +105,14 @@ class ParallelTempering(Strategy):
         if self.verbose:
             mean_accs = jnp.mean(do_accepts)
             print("Mean acceptance of individual steps in PT: " + str(mean_accs))
+            #print(log_probs)
 
         # Exchange between temperatures
 
         rng_key, subkey = jax.random.split(rng_key)
         subkey = jax.random.split(subkey, initial_position.shape[0])
         positions, log_probs, do_accepts = eqx.filter_jit(
-            eqx.filter_vmap(self._exchange, in_axes=(0, 0, 0, None, None))
+            eqx.filter_vmap(self._exchange, in_axes=(0, 0, None, None, None))
         )(subkey, positions, tempered_logpdf, temperatures.data, data)
 
 
@@ -129,6 +130,7 @@ class ParallelTempering(Strategy):
                 eqx.filter_jit(self._adapt_temperature)(temperatures.data, do_accepts),
                 0,
             )
+
 
         return rng_key, resources, positions[:, 0]
 
@@ -232,7 +234,7 @@ class ParallelTempering(Strategy):
                 - log_probs (Float[Array, "1"]): Log probabilities of the chain.
                 - do_accept (Int[Array, "1"]): Acceptance flag for the new position.
         """
-        log_probs = logpdf(positions, data)
+        log_probs = jax.tree_util.Partial(logpdf.tempered_log_pdf, temperatures)(positions, data)
 
         (key, position, log_prob, logpdf, temperatures, data), (
             positions,
@@ -317,10 +319,11 @@ class ParallelTempering(Strategy):
         ratio = (1.0 / temperatures[idx + 1] - 1.0 / temperatures[idx]) * (
             log_probs[idx] - log_probs[idx + 1]
         )
-        #jax.debug.print("ratio: {}, idx: {}, idx+1:{}, temperature: {}, temperature+1: {}", ratio, log_probs[idx], log_probs[idx+1], temperatures[idx], temperatures[idx+1])
         log_uniform = jnp.log(jax.random.uniform(subkey))
         do_accept: Bool[Array, " 1"] = log_uniform < ratio
-        swapped = jnp.flip(jax.lax.dynamic_slice_in_dim(positions, idx, 2, axis=0))
+        swapped = jnp.flip(jax.lax.dynamic_slice_in_dim(positions, idx, 2, axis=0),axis=0)
+#        jax.debug.print("Before idx: {}, ratio: {}, idx: {}, temperature: {}, do_accept: {}", idx, ratio, log_probs,  temperatures, do_accept)
+#        jax.debug.print("Before {}, {}, {}", idx, positions, do_accept)
         positions = jax.lax.cond(
             do_accept,
             true_fun=lambda: jax.lax.dynamic_update_slice_in_dim(
@@ -328,14 +331,16 @@ class ParallelTempering(Strategy):
             ),
             false_fun=lambda: positions,
         )
-        swapped_log_probs = jax.vmap(logpdf, in_axes=(0, None))(swapped, data)
+        swapped = jnp.flip(jax.lax.dynamic_slice_in_dim(log_probs, idx, 2, axis=0),axis=0)
         log_probs = jax.lax.cond(
             do_accept,
             true_fun=lambda: jax.lax.dynamic_update_slice_in_dim(
-                log_probs, swapped_log_probs, idx, axis=0
+                log_probs, swapped, idx, axis=0
             ),
             false_fun=lambda: log_probs,
         )
+#        jax.debug.print("compute log_prob {}", jax.vmap(logpdf, in_axes=(0, None))(positions, {}))
+#        jax.debug.print("new log_prob {}", log_probs)
         return (key, positions, log_probs, idx+1, logpdf, temperatures, data), do_accept
 
     def _exchange(
@@ -404,7 +409,7 @@ class ParallelTempering(Strategy):
             print("Adapting temperatures")
 
         acceptance_rate = jnp.mean(do_accept, axis=0)
-        damping_factor = acceptance_rate[:-1] - acceptance_rate[1:]
+        damping_factor = (100./do_accept.shape[0])*(acceptance_rate[:-1] - acceptance_rate[1:])
         new_temperatures = temperatures
         for i in range(1, temperatures.shape[0] - 1):
             new_temperatures = new_temperatures.at[i].set(
@@ -412,5 +417,5 @@ class ParallelTempering(Strategy):
                 + (temperatures[i] - temperatures[i - 1]) * jnp.exp(damping_factor[i-1])
             )
 
-        # jax.debug.print("{} {} {} {}", temperatures, acceptance_rate, damping_factor, new_temperatures )
+        #jax.debug.print("{} {} {} {}", temperatures, acceptance_rate, damping_factor, new_temperatures )
         return new_temperatures

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -65,8 +65,10 @@ class TrainModel(Strategy):
         ), "Optimizer resource must be an optimizer"
         n_chains = data_resource.data.shape[0]
         n_dims = data_resource.data.shape[-1]
-        training_data = data_resource.data[jnp.isfinite(data_resource.data).all(axis=-1)].reshape(n_chains,-1,n_dims)
-        training_data = training_data[:, -self.history_window:].reshape(-1, n_dims)
+        training_data = data_resource.data[
+            jnp.isfinite(data_resource.data).all(axis=-1)
+        ].reshape(n_chains, -1, n_dims)
+        training_data = training_data[:, -self.history_window :].reshape(-1, n_dims)
         subkey, rng_key = jax.random.split(rng_key)
         training_data = training_data[
             jax.random.choice(

--- a/src/flowMC/strategy/train_model.py
+++ b/src/flowMC/strategy/train_model.py
@@ -30,7 +30,7 @@ class TrainModel(Strategy):
         n_epochs: int = 100,
         batch_size: int = 64,
         n_max_examples: int = 10000,
-        thinning: int = 1,
+        history_window: int = 100,
         verbose: bool = False,
     ):
         self.model_resource = model_resource
@@ -42,7 +42,7 @@ class TrainModel(Strategy):
         self.batch_size = batch_size
         self.n_max_examples = n_max_examples
         self.verbose = verbose
-        self.thinning = thinning
+        self.history_window = history_window
 
     def __call__(
         self,
@@ -63,10 +63,10 @@ class TrainModel(Strategy):
         assert isinstance(
             optimizer, Optimizer
         ), "Optimizer resource must be an optimizer"
-        training_data = data_resource.data.reshape(-1, data_resource.shape[-1])[
-            :: self.thinning
-        ]
-        training_data = training_data[jnp.isfinite(training_data).all(axis=1)]
+        n_chains = data_resource.data.shape[0]
+        n_dims = data_resource.data.shape[-1]
+        training_data = data_resource.data[jnp.isfinite(data_resource.data).all(axis=-1)].reshape(n_chains,-1,n_dims)
+        training_data = training_data[:, -self.history_window:].reshape(-1, n_dims)
         subkey, rng_key = jax.random.split(rng_key)
         training_data = training_data[
             jax.random.choice(

--- a/test/unit/test_strategies.py
+++ b/test/unit/test_strategies.py
@@ -206,7 +206,7 @@ class TestNFStrategies:
             n_epochs=10,
             batch_size=self.n_chains * self.n_steps,
             n_max_examples=10000,
-            thinning=1,
+            history_window=1,
             verbose=True,
         )
 


### PR DESCRIPTION
This PR rolls out a couple of bug fixes and tuning based on integrating the parallel tempering strategy in `flowMC` into another package I maintain. Outside of the tuning in the parallel tempering strategy, the main changes is in the train model. 

In the previous version the `train_model` method randomly sample from all the historical chains. In this version it only takes from a number of most recent steps.

**The following messages are generated by copilot**

This pull request includes several changes to improve the functionality and performance of the `flowMC` package, specifically focusing on the `resource_strategy_bundle` and `strategy` modules. The key changes involve adding a new `history_window` parameter, reordering steps in certain methods, and enhancing logging and debugging capabilities.

### Enhancements to `resource_strategy_bundle`:

* Added a new `history_window` parameter to the `__init__` method in `RQSpline_MALA_PT.py` and updated its usage in the method. [[1]](diffhunk://#diff-4f879102f7b1daa45b0476fc33496d3a5e10538b0ceb1bb88d917cb77441b08fL60-R65) [[2]](diffhunk://#diff-4f879102f7b1daa45b0476fc33496d3a5e10538b0ceb1bb88d917cb77441b08fR185)

* Reordered the `parallel_tempering` step in the `initialize_tempered_positions` method to ensure it is executed at the correct phase. [[1]](diffhunk://#diff-4f879102f7b1daa45b0476fc33496d3a5e10538b0ceb1bb88d917cb77441b08fR313-L313) [[2]](diffhunk://#diff-4f879102f7b1daa45b0476fc33496d3a5e10538b0ceb1bb88d917cb77441b08fL322-R326)

### Improvements to `strategy` module:

* Added verbose logging to the `__call__` method in `parallel_tempering.py` to print mean acceptance rates for individual and exchange steps. [[1]](diffhunk://#diff-9de9babeb150a0db94d8b1e1be80c2cd90e5c9ed306d8532e727cb02eb4a2474R105-R122) [[2]](diffhunk://#diff-9de9babeb150a0db94d8b1e1be80c2cd90e5c9ed306d8532e727cb02eb4a2474R134)

* Updated the `_individual_step` method to use `jax.tree_util.Partial` for computing log probabilities.

* Fixed the `_exchange_step_body` method to correctly handle log probabilities and added debug print statements for better traceability.

* Adjusted the temperature adaptation logic in `_adapt_temperature` to include a damping factor based on the acceptance rate.

### Changes to `train_model`:

* Replaced the `thinning` parameter with `history_window` in the `__init__` method and updated its usage in the `__call__` method to reshape training data accordingly. [[1]](diffhunk://#diff-179fa5500d1430af4d8a81b736a5176d12147d49683114259dab55292b18352fL33-R33) [[2]](diffhunk://#diff-179fa5500d1430af4d8a81b736a5176d12147d49683114259dab55292b18352fL45-R45) [[3]](diffhunk://#diff-179fa5500d1430af4d8a81b736a5176d12147d49683114259dab55292b18352fL66-R69)